### PR TITLE
Expose commit parents attribute in commit table

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -23,6 +23,7 @@ var CommitsSchema = sql.Schema{
 	{Name: "committer_when", Type: sql.Timestamp, Nullable: false, Source: CommitsTableName},
 	{Name: "message", Type: sql.Text, Nullable: false, Source: CommitsTableName},
 	{Name: "tree_hash", Type: sql.Text, Nullable: false, Source: CommitsTableName},
+	{Name: "parents", Type: sql.Array(sql.Text), Nullable: false, Source: CommitsTableName},
 }
 
 var _ sql.PushdownProjectionAndFiltersTable = (*commitsTable)(nil)
@@ -186,5 +187,15 @@ func commitToRow(c *object.Commit) sql.Row {
 		c.Committer.When,
 		c.Message,
 		c.TreeHash.String(),
+		getParentHashes(c),
 	)
+}
+
+func getParentHashes(c *object.Commit) []interface{} {
+	parentHashes := make([]interface{}, 0, len(c.ParentHashes))
+	for _, plumbingHash := range c.ParentHashes {
+		parentHashes = append(parentHashes, plumbingHash.String())
+	}
+
+	return parentHashes
 }

--- a/commits_test.go
+++ b/commits_test.go
@@ -111,3 +111,96 @@ func TestCommitsPushdown(t *testing.T) {
 	require.NoError(err)
 	require.Len(rows, 1)
 }
+
+func TestCommitsParents(t *testing.T) {
+	session, _, cleanup := setup(t)
+	defer cleanup()
+
+	table := newCommitsTable()
+	iter, err := table.RowIter(session)
+	require.NoError(t, err)
+
+	rows, err := sql.RowIterToRows(iter)
+	require.NoError(t, err)
+	require.Len(t, rows, 9)
+
+	tests := []struct {
+		name    string
+		hash    string
+		parents []string
+	}{
+		{
+			name: "test commits parents 1",
+			hash: "e8d3ffab552895c19b9fcf7aa264d277cde33881",
+			parents: []string{
+				"918c48b83bd081e863dbe1b80f8998f058cd8294",
+			},
+		},
+		{
+			name: "test commits parents 2",
+			hash: "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			parents: []string{
+				"918c48b83bd081e863dbe1b80f8998f058cd8294",
+			},
+		},
+		{
+			name: "test commits parents 3",
+			hash: "918c48b83bd081e863dbe1b80f8998f058cd8294",
+			parents: []string{
+				"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+			},
+		},
+		{
+			name: "test commits parents 4",
+			hash: "af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+			parents: []string{
+				"1669dce138d9b841a518c64b10914d88f5e488ea",
+			},
+		},
+		{
+			name: "test commits parents 5",
+			hash: "1669dce138d9b841a518c64b10914d88f5e488ea",
+			parents: []string{
+				"35e85108805c84807bc66a02d91535e1e24b38b9",
+				"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+			},
+		},
+		{
+			name: "test commits parents 6",
+			hash: "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+			parents: []string{
+				"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+				"b8e471f58bcbca63b07bda20e428190409c2db47",
+			},
+		},
+		{
+			name: "test commits parents 7",
+			hash: "b8e471f58bcbca63b07bda20e428190409c2db47",
+			parents: []string{
+				"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+			},
+		},
+		{
+			name: "test commits parents 8",
+			hash: "35e85108805c84807bc66a02d91535e1e24b38b9",
+			parents: []string{
+				"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+			},
+		},
+		{
+			name:    "test commits parents 9",
+			hash:    "b029517f6300c2da0f4b651b8642506cd6aaf45d",
+			parents: []string{},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hash := rows[i][0]
+			parents := rows[i][9]
+			require.Equal(t, test.hash, hash)
+			require.ElementsMatch(t, test.parents, parents)
+		})
+	}
+
+}

--- a/internal/rule/squashjoins_test.go
+++ b/internal/rule/squashjoins_test.go
@@ -73,7 +73,7 @@ func TestSquashJoins(t *testing.T) {
 					nil,
 					false,
 				),
-				[]int{4, 5, 6, 7, 8, 9, 10, 11, 12, 0, 1, 2, 3},
+				[]int{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 1, 2, 3},
 				gitbase.RepositoriesTableName,
 				gitbase.ReferencesTableName,
 				gitbase.CommitsTableName,


### PR DESCRIPTION
A new attribute `parents` has been added to the `commits` table containing an array with each commit's parent hashes.
```
MySQL [(none)]> DESCRIBE TABLE commits;
+------+------+
| name | type |
+------+------+
| hash | TEXT |
| author_name | TEXT |
| author_email | TEXT |
| author_when | TIMESTAMP |
| committer_name | TEXT |
| committer_email | TEXT |
| committer_when | TIMESTAMP |
| message | TEXT |
| tree_hash | TEXT |
| parents | JSON |
+------+------+
10 rows in set (0.00 sec)
```

```
MySQL [(none)]> select hash,committer_name,parents from commits where array_length(parents) > 1 limit 10;
+------+----------------+---------+
| hash | committer_name | parents |
+------+----------------+---------+
| c1a24566f4a89001ade1441dfbd7d98a2bd93ba8 | R.J.V. Bertin  | ["e997744cc641628d28928d830ecf7ec619308d57","6c92e0f8307e79564fe305dee6b3ad5f3df11fb7"] |
| fc56503d7278925acac8f92749f0808db7ffa248 | René J.V. Bertin | ["dc876b06c1cca76d0fcab99588cff3afcdb2f39b","67809e220b47bae81e726d170fd5beb1b41dbeb5"] |
| 81b0c971b414f2d3687c9c837a3b150cfbe4c9c8 | Alexander Potashev | ["b6913c136d8d2ca1216b8c64790b2832f337931a","c8a7b1e5dca1ba6a04c2f117e7d09c607ba15f32"] |
| f1fa0c18ab2148d208920aeaa8787548ed47ae88 | Michael Palimaka | ["9a190c14d853b46c24d326063f913c3efe384f9b","2dce7ebe83e24451053aaa5ffe3822b5f1cb14b9"] |
| 8a4e4ab5e2788fbd688a2d161bb2f70ab2c8e7f1 | Harald Sitter  | ["a69a759297b0b936617456712abf98b7efdd90a0","496f618a970c17568976b4fece4222e4ac55257b"] |
| afd851908793496f47d921c02fa56855a1200cc2 | Aleix Pol      | ["ba6956e6242d25360110a9bbf838d2eb3fb77479","73df960e45ff0bf58865c18be43381d8f4da3d8e"] |
| 7d15e6a9d071032a8783471b4e3518cf5388dfaf | Lingerhk       | ["9189de7f9cb11ebb6fc6cf304c035d5f1f41b9ed","3eae80004b064f155604519d5a92ad80a0f521f7"] |
| 7a3b4628002d59e8a6faa0bb057873c95a5c5b8d | wangbo         | ["be3476f843480c101d5291317df364460d7abec1","1008be932248a16e5a9500be4129efeeb4564b39"] |
| 01348bced4cd560ca86a02bf484988da134f7d3f | wangbo         | ["fff7062de8474d10a67d417ccea87ba6f58ca81d","563524c36b5e80acfd1ff0aca2386e934e4fa625"] |
| d25925ced790fa79290dc47de3336cdb73004061 | linky          | ["42c74a8b0b7e8d0afc3275e409bfba5c15fe8af6","cd9e145151fb50885fc17294dc57746fcce04801"] |
+------+----------------+---------+
10 rows in set (0.16 sec)
```

Closes #226 