### PR TITLE
*: rename columns for easier natural joins, add repository_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ A MySQL client is needed to connect to the server. For example:
 
 ```bash
 $ mysql -q -u root -h 127.0.0.1
-MySQL [(none)]> SELECT hash, author_email, author_name FROM commits LIMIT 2;
-SELECT hash, author_email, author_name FROM commits LIMIT 2;
+MySQL [(none)]> SELECT commit_hash, commit_author_email, commit_author_name FROM commits LIMIT 2;
+SELECT commit_hash, commit_author_email, commit_author_name FROM commits LIMIT 2;
 +------------------------------------------+---------------------+-----------------------+
-| hash                                     | author_email        | author_name           |
+| commit_hash                              | commit_author_email | commit_author_name    |
 +------------------------------------------+---------------------+-----------------------+
 | 003dc36e0067b25333cb5d3a5ccc31fd028a1c83 | user1@test.io       | Santiago M. Mola      |
 | 01ace9e4d144aaeb50eb630fed993375609bcf55 | user2@test.io       | Antonio Navarro Perez |
@@ -70,13 +70,13 @@ gitbase exposes the following tables:
 
 |     Name     |                                               Columns                                                             |
 |:-------------|:------------------------------------------------------------------------------------------------------------------|
-| repositories | id                                                                                                                |
-| remotes      | repository_id, name, push_url, fetch_url, push_refspec, fetch_refspec                                             |
-| commits      | hash, author_name, author_email, author_when, committer_name, committer_email, committer_when, message, tree_hash |
-| blobs        | hash, size, content                                                                                               |
-| refs         | repository_id, name, hash                                                                                         |
-| tree_entries | tree_hash, entry_hash, mode, name                                                                                 |
-| references   | repository_id, name, hash                                                                                         |
+| repositories | repository_id                                                                                                                |
+| remotes      | repository_id, remote_name, remote_push_url, remote_fetch_url, remote_push_refspec, remote_fetch_refspec                                             |
+| commits      | repository_id, commit_hash, commit_author_name, commit_author_email, commit_author_when, committer_name, committer_email, committer_when, commit_message, tree_hash |
+| blobs        | repository_id, blob_hash, blob_size, blob_content                                                                                               |
+| refs         | repository_id, ref_name, commit_hash                                                                                         |
+| tree_entries | repository_id, tree_hash, blob_hash, tree_entry_mode, tree_entry_name                                                                                 |
+| references   | repository_id, ref_name, commit_hash                                                                                         |
 
 ## Functions
 
@@ -101,30 +101,30 @@ To make some common tasks easier for the user, there are some functions to inter
 
 ### Get all the HEAD references from all the repositories
 ```sql
-SELECT * FROM refs WHERE name = 'HEAD'
+SELECT * FROM refs WHERE ref_name = 'HEAD'
 ```
 
 ### Commits that appears in more than one reference
 
 ```sql
 SELECT * FROM (
-	SELECT COUNT(c.hash) AS num, c.hash
+	SELECT COUNT(c.commit_hash) AS num, c.commit_hash
 	FROM refs r
 	INNER JOIN commits c
-		ON history_idx(r.hash, c.hash) >= 0
-	GROUP BY c.hash
+		ON history_idx(r.commit_hash, c.commit_hash) >= 0
+	GROUP BY c.commit_hash
 ) t WHERE num > 1
 ```
 
 ###  Get the number of blobs per HEAD commit
 ```sql
-SELECT COUNT(c.hash), c.hash
+SELECT COUNT(c.commit_hash), c.commit_hash
 FROM refs r
 INNER JOIN commits c
-	ON r.name = 'HEAD' AND history_idx(r.hash, c.hash) >= 0
+	ON r.ref_name = 'HEAD' AND history_idx(r.commit_hash, c.commit_hash) >= 0
 INNER JOIN blobs b
-	ON commit_has_blob(c.hash, b.hash)
-GROUP BY c.hash
+	ON commit_has_blob(c.commit_hash, b.commit_hash)
+GROUP BY c.commit_hash
 ```
 
 ### Get commits per commiter, per month in 2015
@@ -134,11 +134,11 @@ SELECT COUNT(*) as num_commits, month, repo_id, committer_email
 	FROM (
 		SELECT
 			MONTH(committer_when) as month,
-			r.id as repo_id,
+			r.repository_id as repo_id,
 			committer_email
 		FROM repositories r
-		INNER JOIN refs ON refs.repository_id = r.id AND refs.name = 'HEAD'
-		INNER JOIN commits c ON YEAR(committer_when) = 2015 AND history_idx(refs.hash, c.hash) >= 0
+		INNER JOIN refs ON refs.repository_id = r.repository_id AND refs.ref_name = 'HEAD'
+		INNER JOIN commits c ON YEAR(committer_when) = 2015 AND history_idx(refs.commit_hash, c.commit_hash) >= 0
 	) as t
 GROUP BY committer_email, month, repo_id
 ```

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -83,9 +83,9 @@ func TestBlobsLimit(t *testing.T) {
 	require.Len(rows, len(expected))
 	for i, row := range rows {
 		e := expected[i]
-		require.Equal(e.hash, row[0].(string))
-		require.Equal(e.bytes, row[1].(int64))
-		require.Equal(e.empty, len(row[2].([]byte)) == 0)
+		require.Equal(e.hash, row[1].(string))
+		require.Equal(e.bytes, row[2].(int64))
+		require.Equal(e.empty, len(row[3].([]byte)) == 0)
 	}
 }
 
@@ -105,7 +105,7 @@ func TestBlobsPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(0, sql.Text, BlobsTableName, "hash", false),
+			expression.NewGetFieldWithTable(1, sql.Text, BlobsTableName, "blob_hash", false),
 			expression.NewLiteral("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88", sql.Text),
 		),
 	})
@@ -117,7 +117,7 @@ func TestBlobsPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewLessThan(
-			expression.NewGetFieldWithTable(1, sql.Int64, BlobsTableName, "size", false),
+			expression.NewGetFieldWithTable(2, sql.Int64, BlobsTableName, "blob_size", false),
 			expression.NewLiteral(int64(10), sql.Int64),
 		),
 	})
@@ -125,7 +125,7 @@ func TestBlobsPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(0, sql.Text, BlobsTableName, "hash", false),
+			expression.NewGetFieldWithTable(1, sql.Text, BlobsTableName, "blob_hash", false),
 			expression.NewLiteral("not exists", sql.Text),
 		),
 	})

--- a/commits_test.go
+++ b/commits_test.go
@@ -61,7 +61,7 @@ func TestCommitsPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(0, sql.Text, CommitsTableName, "hash", false),
+			expression.NewGetFieldWithTable(1, sql.Text, CommitsTableName, "blob_hash", false),
 			expression.NewLiteral("918c48b83bd081e863dbe1b80f8998f058cd8294", sql.Text),
 		),
 	})
@@ -73,7 +73,7 @@ func TestCommitsPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(0, sql.Text, CommitsTableName, "hash", false),
+			expression.NewGetFieldWithTable(1, sql.Text, CommitsTableName, "blob_hash", false),
 			expression.NewLiteral("not exists", sql.Text),
 		),
 	})
@@ -85,7 +85,7 @@ func TestCommitsPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(2, sql.Text, CommitsTableName, "author_email", false),
+			expression.NewGetFieldWithTable(3, sql.Text, CommitsTableName, "commit_author_email", false),
 			expression.NewLiteral("mcuadros@gmail.com", sql.Text),
 		),
 	})
@@ -97,11 +97,11 @@ func TestCommitsPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(2, sql.Text, CommitsTableName, "author_email", false),
+			expression.NewGetFieldWithTable(3, sql.Text, CommitsTableName, "commit_author_email", false),
 			expression.NewLiteral("mcuadros@gmail.com", sql.Text),
 		),
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(7, sql.Text, CommitsTableName, "message", false),
+			expression.NewGetFieldWithTable(8, sql.Text, CommitsTableName, "commit_message", false),
 			expression.NewLiteral("vendor stuff\n", sql.Text),
 		),
 	})
@@ -196,8 +196,8 @@ func TestCommitsParents(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			hash := rows[i][0]
-			parents := rows[i][9]
+			hash := rows[i][1]
+			parents := rows[i][10]
 			require.Equal(t, test.hash, hash)
 			require.ElementsMatch(t, test.parents, parents)
 		})

--- a/internal/function/uast.go
+++ b/internal/function/uast.go
@@ -204,11 +204,14 @@ func (f UAST) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		}
 	}
 
-	var result = make([]interface{}, len(nodes))
-	for i, n := range nodes {
-		result[i], err = n.Marshal()
-		if err != nil {
-			return nil, err
+	var result = make([]interface{}, 0, len(nodes))
+	for _, n := range nodes {
+		if n != nil {
+			node, err := n.Marshal()
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, node)
 		}
 	}
 

--- a/internal/rule/squashjoins.go
+++ b/internal/rule/squashjoins.go
@@ -314,7 +314,7 @@ func buildSquashedTable(
 		case gitbase.BlobsTableName:
 			var readContent bool
 			for _, e := range columns {
-				if containsField(e, gitbase.BlobsTableName, "content") {
+				if containsField(e, gitbase.BlobsTableName, "blob_content") {
 					readContent = true
 					break
 				}
@@ -747,8 +747,8 @@ func removeRedundantFilters(filters []sql.Expression, t1, t2 string) []sql.Expre
 func hasRefHEADFilter(filters []sql.Expression) bool {
 	for _, f := range filters {
 		ok := isEq(
-			isCol(gitbase.ReferencesTableName, "hash"),
-			isCol(gitbase.CommitsTableName, "hash"),
+			isCol(gitbase.ReferencesTableName, "commit_hash"),
+			isCol(gitbase.CommitsTableName, "commit_hash"),
 		)(f)
 		if ok {
 			return true
@@ -788,12 +788,12 @@ func isRedundantFilter(f sql.Expression, t1, t2 string) bool {
 	switch true {
 	case t1 == gitbase.RepositoriesTableName && t2 == gitbase.RemotesTableName:
 		return isEq(
-			isCol(gitbase.RepositoriesTableName, "id"),
+			isCol(gitbase.RepositoriesTableName, "repository_id"),
 			isCol(gitbase.RemotesTableName, "repository_id"),
 		)(f)
 	case t1 == gitbase.RepositoriesTableName && t2 == gitbase.ReferencesTableName:
 		return isEq(
-			isCol(gitbase.RepositoriesTableName, "id"),
+			isCol(gitbase.RepositoriesTableName, "repository_id"),
 			isCol(gitbase.ReferencesTableName, "repository_id"),
 		)(f)
 	case t1 == gitbase.RemotesTableName && t2 == gitbase.ReferencesTableName:
@@ -803,48 +803,48 @@ func isRedundantFilter(f sql.Expression, t1, t2 string) bool {
 		)(f)
 	case t1 == gitbase.ReferencesTableName && t2 == gitbase.CommitsTableName:
 		return isEq(
-			isCol(gitbase.ReferencesTableName, "hash"),
-			isCol(gitbase.CommitsTableName, "hash"),
+			isCol(gitbase.ReferencesTableName, "commit_hash"),
+			isCol(gitbase.CommitsTableName, "commit_hash"),
 		)(f) || isGte(
 			isHistoryIdx(
-				isCol(gitbase.ReferencesTableName, "hash"),
-				isCol(gitbase.CommitsTableName, "hash"),
+				isCol(gitbase.ReferencesTableName, "commit_hash"),
+				isCol(gitbase.CommitsTableName, "commit_hash"),
 			),
 			isNum(0),
 		)(f)
 	case t1 == gitbase.ReferencesTableName && t2 == gitbase.TreeEntriesTableName:
 		return isCommitHasTree(
-			isCol(gitbase.ReferencesTableName, "hash"),
+			isCol(gitbase.ReferencesTableName, "commit_hash"),
 			isCol(gitbase.TreeEntriesTableName, "tree_hash"),
 		)(f) || isCommitHasBlob(
-			isCol(gitbase.ReferencesTableName, "hash"),
-			isCol(gitbase.TreeEntriesTableName, "entry_hash"),
+			isCol(gitbase.ReferencesTableName, "commit_hash"),
+			isCol(gitbase.TreeEntriesTableName, "blob_hash"),
 		)(f)
 	case t1 == gitbase.ReferencesTableName && t2 == gitbase.BlobsTableName:
 		return isCommitHasBlob(
-			isCol(gitbase.ReferencesTableName, "hash"),
-			isCol(gitbase.BlobsTableName, "hash"),
+			isCol(gitbase.ReferencesTableName, "commit_hash"),
+			isCol(gitbase.BlobsTableName, "blob_hash"),
 		)(f)
 	case t1 == gitbase.CommitsTableName && t2 == gitbase.TreeEntriesTableName:
 		return isEq(
 			isCol(gitbase.CommitsTableName, "tree_hash"),
 			isCol(gitbase.TreeEntriesTableName, "tree_hash"),
 		)(f) || isCommitHasTree(
-			isCol(gitbase.CommitsTableName, "hash"),
+			isCol(gitbase.CommitsTableName, "commit_hash"),
 			isCol(gitbase.TreeEntriesTableName, "tree_hash"),
 		)(f) || isCommitHasBlob(
-			isCol(gitbase.CommitsTableName, "hash"),
-			isCol(gitbase.TreeEntriesTableName, "entry_hash"),
+			isCol(gitbase.CommitsTableName, "commit_hash"),
+			isCol(gitbase.TreeEntriesTableName, "blob_hash"),
 		)(f)
 	case t1 == gitbase.CommitsTableName && t2 == gitbase.BlobsTableName:
 		return isCommitHasBlob(
-			isCol(gitbase.CommitsTableName, "hash"),
-			isCol(gitbase.BlobsTableName, "hash"),
+			isCol(gitbase.CommitsTableName, "commit_hash"),
+			isCol(gitbase.BlobsTableName, "blob_hash"),
 		)(f)
 	case t1 == gitbase.TreeEntriesTableName && t2 == gitbase.BlobsTableName:
 		return isEq(
-			isCol(gitbase.TreeEntriesTableName, "entry_hash"),
-			isCol(gitbase.BlobsTableName, "hash"),
+			isCol(gitbase.TreeEntriesTableName, "blob_hash"),
+			isCol(gitbase.BlobsTableName, "blob_hash"),
 		)(f)
 	}
 	return false

--- a/internal/rule/squashjoins_test.go
+++ b/internal/rule/squashjoins_test.go
@@ -38,7 +38,7 @@ func TestSquashJoins(t *testing.T) {
 					),
 					and(
 						eq(
-							col(0, gitbase.RepositoriesTableName, "id"),
+							col(0, gitbase.RepositoriesTableName, "repository_id"),
 							col(0, gitbase.ReferencesTableName, "repository_id"),
 						),
 						lit(4),
@@ -46,8 +46,8 @@ func TestSquashJoins(t *testing.T) {
 				),
 				and(
 					eq(
-						col(0, gitbase.ReferencesTableName, "hash"),
-						col(0, gitbase.CommitsTableName, "hash"),
+						col(0, gitbase.ReferencesTableName, "commit_hash"),
+						col(0, gitbase.CommitsTableName, "commit_hash"),
 					),
 					lit(3),
 				),
@@ -73,7 +73,7 @@ func TestSquashJoins(t *testing.T) {
 					nil,
 					false,
 				),
-				[]int{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 1, 2, 3},
+				[]int{4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0, 1, 2, 3},
 				gitbase.RepositoriesTableName,
 				gitbase.ReferencesTableName,
 				gitbase.CommitsTableName,
@@ -134,7 +134,7 @@ func TestSquashJoinsPartial(t *testing.T) {
 				),
 				and(
 					eq(
-						col(0, gitbase.RepositoriesTableName, "id"),
+						col(0, gitbase.RepositoriesTableName, "repository_id"),
 						col(0, gitbase.ReferencesTableName, "repository_id"),
 					),
 					lit(4),
@@ -190,7 +190,7 @@ func TestSquashJoinsSchema(t *testing.T) {
 			),
 			and(
 				eq(
-					col(0, gitbase.RepositoriesTableName, "id"),
+					col(0, gitbase.RepositoriesTableName, "repository_id"),
 					col(0, gitbase.ReferencesTableName, "repository_id"),
 				),
 				lit(4),
@@ -198,8 +198,8 @@ func TestSquashJoinsSchema(t *testing.T) {
 		),
 		and(
 			eq(
-				col(0, gitbase.ReferencesTableName, "hash"),
-				col(0, gitbase.CommitsTableName, "hash"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
+				col(0, gitbase.CommitsTableName, "commit_hash"),
 			),
 			lit(3),
 		),
@@ -235,18 +235,18 @@ func TestBuildSquashedTable(t *testing.T) {
 	commitBlobsSchema := append(gitbase.CommitsSchema, gitbase.BlobsSchema...)
 
 	repoFilter := eq(
-		col(0, gitbase.RepositoriesTableName, "id"),
-		col(0, gitbase.RepositoriesTableName, "id"),
+		col(0, gitbase.RepositoriesTableName, "repository_id"),
+		col(0, gitbase.RepositoriesTableName, "repository_id"),
 	)
 
 	repoRemotesRedundantFilter := eq(
-		col(0, gitbase.RepositoriesTableName, "id"),
+		col(0, gitbase.RepositoriesTableName, "repository_id"),
 		col(1, gitbase.RemotesTableName, "repository_id"),
 	)
 
 	repoRemotesFilter := eq(
-		col(0, gitbase.RepositoriesTableName, "id"),
-		col(2, gitbase.RemotesTableName, "name"),
+		col(0, gitbase.RepositoriesTableName, "repository_id"),
+		col(2, gitbase.RemotesTableName, "remote_name"),
 	)
 
 	remotesFilter := eq(
@@ -260,8 +260,8 @@ func TestBuildSquashedTable(t *testing.T) {
 	)
 
 	remoteRefsFilter := eq(
-		col(2, gitbase.RemotesTableName, "name"),
-		col(8, gitbase.ReferencesTableName, "name"),
+		col(2, gitbase.RemotesTableName, "remote_name"),
+		col(8, gitbase.ReferencesTableName, "ref_name"),
 	)
 
 	remoteRefsRedundantFilter := eq(
@@ -270,50 +270,50 @@ func TestBuildSquashedTable(t *testing.T) {
 	)
 
 	repoRefsFilter := eq(
-		col(0, gitbase.RepositoriesTableName, "id"),
-		col(2, gitbase.ReferencesTableName, "name"),
+		col(0, gitbase.RepositoriesTableName, "repository_id"),
+		col(2, gitbase.ReferencesTableName, "ref_name"),
 	)
 
 	repoRefsRedundantFilter := eq(
-		col(0, gitbase.RepositoriesTableName, "id"),
+		col(0, gitbase.RepositoriesTableName, "repository_id"),
 		col(1, gitbase.ReferencesTableName, "repository_id"),
 	)
 
 	commitFilter := eq(
-		col(4, gitbase.CommitsTableName, "hash"),
-		col(4, gitbase.CommitsTableName, "hash"),
+		col(4, gitbase.CommitsTableName, "commit_hash"),
+		col(4, gitbase.CommitsTableName, "commit_hash"),
 	)
 
 	refCommitsRedundantFilter := gte(
 		historyIdx(
-			col(2, gitbase.ReferencesTableName, "hash"),
-			col(4, gitbase.CommitsTableName, "hash"),
+			col(2, gitbase.ReferencesTableName, "commit_hash"),
+			col(4, gitbase.CommitsTableName, "commit_hash"),
 		),
 		lit(int64(0)),
 	)
 
 	refHEADCommitsRedundantFilter := eq(
-		col(2, gitbase.ReferencesTableName, "hash"),
-		col(4, gitbase.CommitsTableName, "hash"),
+		col(2, gitbase.ReferencesTableName, "commit_hash"),
+		col(4, gitbase.CommitsTableName, "commit_hash"),
 	)
 
 	refCommitsFilter := eq(
-		col(2, gitbase.ReferencesTableName, "hash"),
-		col(4, gitbase.CommitsTableName, "author_name"),
+		col(2, gitbase.ReferencesTableName, "commit_hash"),
+		col(5, gitbase.CommitsTableName, "commit_author_name"),
 	)
 
 	treeEntryFilter := eq(
-		col(0, gitbase.TreeEntriesTableName, "entry_hash"),
-		col(0, gitbase.TreeEntriesTableName, "entry_hash"),
+		col(0, gitbase.TreeEntriesTableName, "blob_hash"),
+		col(0, gitbase.TreeEntriesTableName, "blob_hash"),
 	)
 
 	commitTreeEntriesFilter := eq(
 		col(0, gitbase.CommitsTableName, "tree_hash"),
-		col(0, gitbase.TreeEntriesTableName, "entry_hash"),
+		col(0, gitbase.TreeEntriesTableName, "blob_hash"),
 	)
 
 	commitTreeEntriesRedundantFilter := commitHasTree(
-		col(0, gitbase.CommitsTableName, "hash"),
+		col(0, gitbase.CommitsTableName, "commit_hash"),
 		col(0, gitbase.TreeEntriesTableName, "tree_hash"),
 	)
 
@@ -323,53 +323,53 @@ func TestBuildSquashedTable(t *testing.T) {
 	)
 
 	refTreeEntriesFilter := eq(
-		col(0, gitbase.ReferencesTableName, "name"),
-		col(0, gitbase.TreeEntriesTableName, "name"),
+		col(0, gitbase.ReferencesTableName, "ref_name"),
+		col(0, gitbase.TreeEntriesTableName, "tree_entry_name"),
 	)
 
 	refTreeEntriesRedundantFilter := commitHasTree(
-		col(0, gitbase.ReferencesTableName, "hash"),
+		col(0, gitbase.ReferencesTableName, "commit_hash"),
 		col(0, gitbase.TreeEntriesTableName, "tree_hash"),
 	)
 
 	blobFilter := eq(
-		col(0, gitbase.BlobsTableName, "hash"),
-		col(0, gitbase.BlobsTableName, "hash"),
+		col(0, gitbase.BlobsTableName, "blob_hash"),
+		col(0, gitbase.BlobsTableName, "blob_hash"),
 	)
 
 	blobContentFilter := eq(
-		col(0, gitbase.BlobsTableName, "content"),
-		col(0, gitbase.BlobsTableName, "content"),
+		col(0, gitbase.BlobsTableName, "blob_content"),
+		col(0, gitbase.BlobsTableName, "blob_content"),
 	)
 
 	treeEntryBlobsRedundantFilter := eq(
-		col(0, gitbase.TreeEntriesTableName, "entry_hash"),
-		col(0, gitbase.BlobsTableName, "hash"),
+		col(0, gitbase.TreeEntriesTableName, "blob_hash"),
+		col(0, gitbase.BlobsTableName, "blob_hash"),
 	)
 
 	treeEntryBlobsFilter := eq(
 		col(0, gitbase.TreeEntriesTableName, "tree_hash"),
-		col(0, gitbase.BlobsTableName, "hash"),
+		col(0, gitbase.BlobsTableName, "blob_hash"),
 	)
 
 	refBlobsRedundantFilter := commitHasBlob(
-		col(0, gitbase.ReferencesTableName, "hash"),
-		col(0, gitbase.BlobsTableName, "hash"),
+		col(0, gitbase.ReferencesTableName, "commit_hash"),
+		col(0, gitbase.BlobsTableName, "blob_hash"),
 	)
 
 	refBlobsFilter := eq(
-		col(0, gitbase.ReferencesTableName, "name"),
-		col(0, gitbase.BlobsTableName, "hash"),
+		col(0, gitbase.ReferencesTableName, "ref_name"),
+		col(0, gitbase.BlobsTableName, "blob_hash"),
 	)
 
 	commitBlobsRedundantFilter := commitHasBlob(
-		col(0, gitbase.CommitsTableName, "hash"),
-		col(0, gitbase.BlobsTableName, "hash"),
+		col(0, gitbase.CommitsTableName, "commit_hash"),
+		col(0, gitbase.BlobsTableName, "blob_hash"),
 	)
 
 	commitBlobsFilter := eq(
-		col(0, gitbase.CommitsTableName, "hash"),
-		col(0, gitbase.BlobsTableName, "size"),
+		col(0, gitbase.CommitsTableName, "commit_hash"),
+		col(0, gitbase.BlobsTableName, "blob_size"),
 	)
 
 	testCases := []struct {
@@ -732,7 +732,7 @@ func TestBuildSquashedTable(t *testing.T) {
 				commitBlobsRedundantFilter,
 			},
 			[]sql.Expression{expression.NewGetFieldWithTable(
-				0, sql.Int64, gitbase.BlobsTableName, "content", false,
+				0, sql.Int64, gitbase.BlobsTableName, "blob_content", false,
 			)},
 			nil,
 			newSquashedTable(
@@ -892,15 +892,15 @@ func TestFiltersForJoin(t *testing.T) {
 
 	filters := []sql.Expression{
 		eq(
-			col(0, gitbase.ReferencesTableName, "hash"),
+			col(0, gitbase.ReferencesTableName, "commit_hash"),
 			lit(0),
 		),
 		eq(
-			col(0, gitbase.RemotesTableName, "name"),
+			col(0, gitbase.RemotesTableName, "remote_name"),
 			lit(1),
 		),
 		eq(
-			col(0, gitbase.RepositoriesTableName, "id"),
+			col(0, gitbase.RepositoriesTableName, "repository_id"),
 			col(0, gitbase.ReferencesTableName, "repository_id"),
 		),
 		eq(
@@ -921,11 +921,11 @@ func TestFiltersForJoin(t *testing.T) {
 	require.Equal(
 		expression.JoinAnd(
 			eq(
-				col(8, gitbase.ReferencesTableName, "hash"),
+				col(8, gitbase.ReferencesTableName, "commit_hash"),
 				lit(0),
 			),
 			eq(
-				col(1, gitbase.RemotesTableName, "name"),
+				col(1, gitbase.RemotesTableName, "remote_name"),
 				lit(1),
 			),
 		),
@@ -938,15 +938,15 @@ func TestFiltersForTable(t *testing.T) {
 
 	filters := []sql.Expression{
 		eq(
-			col(0, gitbase.ReferencesTableName, "hash"),
+			col(0, gitbase.ReferencesTableName, "commit_hash"),
 			lit(0),
 		),
 		eq(
-			col(0, gitbase.ReferencesTableName, "hash"),
+			col(0, gitbase.ReferencesTableName, "commit_hash"),
 			lit(1),
 		),
 		eq(
-			col(0, gitbase.RepositoriesTableName, "id"),
+			col(0, gitbase.RepositoriesTableName, "repository_id"),
 			col(0, gitbase.ReferencesTableName, "repository_id"),
 		),
 	}
@@ -962,11 +962,11 @@ func TestFiltersForTable(t *testing.T) {
 	require.Equal(
 		expression.NewAnd(
 			eq(
-				col(2, gitbase.ReferencesTableName, "hash"),
+				col(2, gitbase.ReferencesTableName, "commit_hash"),
 				lit(0),
 			),
 			eq(
-				col(2, gitbase.ReferencesTableName, "hash"),
+				col(2, gitbase.ReferencesTableName, "commit_hash"),
 				lit(1),
 			),
 		),
@@ -976,12 +976,12 @@ func TestFiltersForTable(t *testing.T) {
 
 func TestRemoveRedundantFilters(t *testing.T) {
 	f1 := eq(
-		col(0, gitbase.RepositoriesTableName, "id"),
+		col(0, gitbase.RepositoriesTableName, "repository_id"),
 		col(0, gitbase.ReferencesTableName, "repository_id"),
 	)
 
 	f2 := eq(
-		col(0, gitbase.RepositoriesTableName, "id"),
+		col(0, gitbase.RepositoriesTableName, "repository_id"),
 		lit(0),
 	)
 
@@ -1015,8 +1015,8 @@ func TestIsJoinCondSquashable(t *testing.T) {
 		commits,
 		and(
 			eq(
-				col(0, gitbase.ReferencesTableName, "hash"),
-				col(0, gitbase.CommitsTableName, "hash"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
+				col(0, gitbase.CommitsTableName, "commit_hash"),
 			),
 			eq(lit(0), lit(1)),
 		),
@@ -1029,8 +1029,8 @@ func TestIsJoinCondSquashable(t *testing.T) {
 		commits,
 		and(
 			eq(
-				col(0, gitbase.ReferencesTableName, "hash"),
-				col(0, gitbase.CommitsTableName, "message"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
+				col(0, gitbase.CommitsTableName, "commit_message"),
 			),
 			eq(lit(0), lit(1)),
 		),
@@ -1048,8 +1048,8 @@ func TestIsJoinCondSquashable(t *testing.T) {
 		commits,
 		and(
 			eq(
-				col(0, gitbase.ReferencesTableName, "hash"),
-				col(0, gitbase.CommitsTableName, "hash"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
+				col(0, gitbase.CommitsTableName, "commit_hash"),
 			),
 			eq(lit(0), lit(1)),
 		),
@@ -1068,7 +1068,7 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.RepositoriesTableName,
 			gitbase.RemotesTableName,
 			eq(
-				col(0, gitbase.RepositoriesTableName, "id"),
+				col(0, gitbase.RepositoriesTableName, "repository_id"),
 				col(0, gitbase.RemotesTableName, "repository_id"),
 			),
 			true,
@@ -1078,7 +1078,7 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.RemotesTableName,
 			eq(
 				col(0, gitbase.RemotesTableName, "repository_id"),
-				col(0, gitbase.RepositoriesTableName, "id"),
+				col(0, gitbase.RepositoriesTableName, "repository_id"),
 			),
 			true,
 		},
@@ -1086,7 +1086,7 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.RepositoriesTableName,
 			gitbase.ReferencesTableName,
 			eq(
-				col(0, gitbase.RepositoriesTableName, "id"),
+				col(0, gitbase.RepositoriesTableName, "repository_id"),
 				col(0, gitbase.ReferencesTableName, "repository_id"),
 			),
 			true,
@@ -1096,7 +1096,7 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.ReferencesTableName,
 			eq(
 				col(0, gitbase.ReferencesTableName, "repository_id"),
-				col(0, gitbase.RepositoriesTableName, "id"),
+				col(0, gitbase.RepositoriesTableName, "repository_id"),
 			),
 			true,
 		},
@@ -1122,8 +1122,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.ReferencesTableName,
 			gitbase.CommitsTableName,
 			eq(
-				col(0, gitbase.ReferencesTableName, "hash"),
-				col(0, gitbase.CommitsTableName, "hash"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
+				col(0, gitbase.CommitsTableName, "commit_hash"),
 			),
 			true,
 		},
@@ -1131,8 +1131,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.ReferencesTableName,
 			gitbase.CommitsTableName,
 			eq(
-				col(0, gitbase.CommitsTableName, "hash"),
-				col(0, gitbase.ReferencesTableName, "hash"),
+				col(0, gitbase.CommitsTableName, "commit_hash"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
 			),
 			true,
 		},
@@ -1141,8 +1141,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.CommitsTableName,
 			gte(
 				historyIdx(
-					col(0, gitbase.ReferencesTableName, "hash"),
-					col(0, gitbase.CommitsTableName, "hash"),
+					col(0, gitbase.ReferencesTableName, "commit_hash"),
+					col(0, gitbase.CommitsTableName, "commit_hash"),
 				),
 				lit(int64(0)),
 			),
@@ -1154,8 +1154,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			lte(
 				lit(int64(0)),
 				historyIdx(
-					col(0, gitbase.ReferencesTableName, "hash"),
-					col(0, gitbase.CommitsTableName, "hash"),
+					col(0, gitbase.ReferencesTableName, "commit_hash"),
+					col(0, gitbase.CommitsTableName, "commit_hash"),
 				),
 			),
 			true,
@@ -1165,8 +1165,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.CommitsTableName,
 			gte(
 				historyIdx(
-					col(0, gitbase.ReferencesTableName, "hash"),
-					col(0, gitbase.CommitsTableName, "hash"),
+					col(0, gitbase.ReferencesTableName, "commit_hash"),
+					col(0, gitbase.CommitsTableName, "commit_hash"),
 				),
 				lit(1),
 			),
@@ -1176,7 +1176,7 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.ReferencesTableName,
 			gitbase.TreeEntriesTableName,
 			commitHasTree(
-				col(0, gitbase.ReferencesTableName, "hash"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
 				col(0, gitbase.TreeEntriesTableName, "tree_hash"),
 			),
 			true,
@@ -1185,8 +1185,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.ReferencesTableName,
 			gitbase.TreeEntriesTableName,
 			commitHasBlob(
-				col(0, gitbase.ReferencesTableName, "hash"),
-				col(0, gitbase.TreeEntriesTableName, "entry_hash"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
+				col(0, gitbase.TreeEntriesTableName, "blob_hash"),
 			),
 			true,
 		},
@@ -1194,8 +1194,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.ReferencesTableName,
 			gitbase.BlobsTableName,
 			commitHasBlob(
-				col(0, gitbase.ReferencesTableName, "hash"),
-				col(0, gitbase.BlobsTableName, "hash"),
+				col(0, gitbase.ReferencesTableName, "commit_hash"),
+				col(0, gitbase.BlobsTableName, "blob_hash"),
 			),
 			true,
 		},
@@ -1203,7 +1203,7 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.CommitsTableName,
 			gitbase.TreeEntriesTableName,
 			commitHasTree(
-				col(0, gitbase.CommitsTableName, "hash"),
+				col(0, gitbase.CommitsTableName, "commit_hash"),
 				col(0, gitbase.TreeEntriesTableName, "tree_hash"),
 			),
 			true,
@@ -1212,8 +1212,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.CommitsTableName,
 			gitbase.TreeEntriesTableName,
 			commitHasBlob(
-				col(0, gitbase.CommitsTableName, "hash"),
-				col(0, gitbase.TreeEntriesTableName, "entry_hash"),
+				col(0, gitbase.CommitsTableName, "commit_hash"),
+				col(0, gitbase.TreeEntriesTableName, "blob_hash"),
 			),
 			true,
 		},
@@ -1239,8 +1239,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.CommitsTableName,
 			gitbase.BlobsTableName,
 			commitHasBlob(
-				col(0, gitbase.CommitsTableName, "hash"),
-				col(0, gitbase.BlobsTableName, "hash"),
+				col(0, gitbase.CommitsTableName, "commit_hash"),
+				col(0, gitbase.BlobsTableName, "blob_hash"),
 			),
 			true,
 		},
@@ -1248,8 +1248,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.TreeEntriesTableName,
 			gitbase.BlobsTableName,
 			eq(
-				col(0, gitbase.TreeEntriesTableName, "entry_hash"),
-				col(0, gitbase.BlobsTableName, "hash"),
+				col(0, gitbase.TreeEntriesTableName, "blob_hash"),
+				col(0, gitbase.BlobsTableName, "blob_hash"),
 			),
 			true,
 		},
@@ -1257,8 +1257,8 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.TreeEntriesTableName,
 			gitbase.BlobsTableName,
 			eq(
-				col(0, gitbase.BlobsTableName, "hash"),
-				col(0, gitbase.TreeEntriesTableName, "entry_hash"),
+				col(0, gitbase.BlobsTableName, "blob_hash"),
+				col(0, gitbase.TreeEntriesTableName, "blob_hash"),
 			),
 			true,
 		},
@@ -1267,7 +1267,7 @@ func TestIsRedundantFilter(t *testing.T) {
 			gitbase.BlobsTableName,
 			eq(
 				col(0, gitbase.TreeEntriesTableName, "tree_hash"),
-				col(0, gitbase.BlobsTableName, "hash"),
+				col(0, gitbase.BlobsTableName, "blob_hash"),
 			),
 			false,
 		},

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -292,7 +292,7 @@ func TestAllCommitsIter(t *testing.T) {
 		t, ctx,
 		NewAllCommitsIter(
 			expression.NewEquals(
-				expression.NewGetField(2, sql.Text, "author_email", false),
+				expression.NewGetField(3, sql.Text, "commit_author_email", false),
 				expression.NewLiteral("mcuadros@gmail.com", sql.Text),
 			),
 		),
@@ -339,11 +339,11 @@ func TestRefCommitsIter(t *testing.T) {
 		t, ctx,
 		NewRefCommitsIter(
 			NewAllRefsIter(expression.NewEquals(
-				expression.NewGetField(1, sql.Text, "name", false),
+				expression.NewGetField(1, sql.Text, "ref_name", false),
 				expression.NewLiteral("HEAD", sql.Text),
 			)),
 			expression.NewEquals(
-				expression.NewGetField(5, sql.Text, "author_email", false),
+				expression.NewGetField(6, sql.Text, "commit_author_email", false),
 				expression.NewLiteral("mcuadros@gmail.com", sql.Text),
 			),
 		),
@@ -394,7 +394,7 @@ func TestRefHEADCommitsIter(t *testing.T) {
 
 	require.Len(rows, len(expected))
 	for _, row := range rows {
-		require.Equal(row[2 /* ref hash */], row[3 /* commit hash */])
+		require.Equal(row[2 /* ref hash */], row[4 /* commit hash */])
 	}
 
 	rows = chainableIterRows(
@@ -402,7 +402,7 @@ func TestRefHEADCommitsIter(t *testing.T) {
 		NewRefHEADCommitsIter(
 			NewAllRefsIter(nil),
 			expression.NewEquals(
-				expression.NewGetField(5, sql.Text, "author_email", false),
+				expression.NewGetField(6, sql.Text, "commit_author_email", false),
 				expression.NewLiteral("mcuadros@gmail.com", sql.Text),
 			),
 			false,
@@ -411,7 +411,7 @@ func TestRefHEADCommitsIter(t *testing.T) {
 
 	require.Len(rows, 7)
 	for _, row := range rows {
-		require.Equal(row[2 /* ref hash */], row[3 /* commit hash */])
+		require.Equal(row[2 /* ref hash */], row[4 /* commit hash */])
 	}
 
 	ctx, cleanup2 := setupIterWithErrors(t, true, true)
@@ -456,7 +456,7 @@ func TestAllTreeEntriesIter(t *testing.T) {
 		t, ctx,
 		NewAllTreeEntriesIter(
 			expression.NewEquals(
-				expression.NewGetField(3, sql.Text, "name", false),
+				expression.NewGetField(4, sql.Text, "tree_entry_name", false),
 				expression.NewLiteral("LICENSE", sql.Text),
 			),
 		),
@@ -604,7 +604,7 @@ func TestTreeEntryBlobsIter(t *testing.T) {
 				false,
 			),
 			expression.NewLessThan(
-				expression.NewGetField(len(CommitsSchema)+len(TreeEntriesSchema)+1, sql.Int64, "size", false),
+				expression.NewGetField(len(CommitsSchema)+len(TreeEntriesSchema)+2, sql.Int64, "blob_size", false),
 				expression.NewLiteral(int64(150), sql.Int64),
 			),
 			false,

--- a/references.go
+++ b/references.go
@@ -15,8 +15,8 @@ type referencesTable struct{}
 // RefsSchema is the schema for the refs table.
 var RefsSchema = sql.Schema{
 	{Name: "repository_id", Type: sql.Text, Nullable: false, Source: ReferencesTableName},
-	{Name: "name", Type: sql.Text, Nullable: false, Source: ReferencesTableName},
-	{Name: "hash", Type: sql.Text, Nullable: false, Source: ReferencesTableName},
+	{Name: "ref_name", Type: sql.Text, Nullable: false, Source: ReferencesTableName},
+	{Name: "commit_hash", Type: sql.Text, Nullable: false, Source: ReferencesTableName},
 }
 
 var _ sql.PushdownProjectionAndFiltersTable = (*referencesTable)(nil)
@@ -81,18 +81,18 @@ func (r *referencesTable) WithProjectAndFilters(
 	span, ctx := ctx.Span("gitbase.ReferencesTable")
 	iter, err := rowIterWithSelectors(
 		ctx, RefsSchema, ReferencesTableName, filters,
-		[]string{"hash", "name"},
+		[]string{"commit_hash", "ref_name"},
 		func(selectors selectors) (RowRepoIter, error) {
-			if len(selectors["hash"]) == 0 && len(selectors["name"]) == 0 {
+			if len(selectors["commit_hash"]) == 0 && len(selectors["ref_name"]) == 0 {
 				return new(referenceIter), nil
 			}
 
-			hashes, err := selectors.textValues("hash")
+			hashes, err := selectors.textValues("commit_hash")
 			if err != nil {
 				return nil, err
 			}
 
-			names, err := selectors.textValues("name")
+			names, err := selectors.textValues("ref_name")
 			if err != nil {
 				return nil, err
 			}

--- a/remotes.go
+++ b/remotes.go
@@ -12,11 +12,11 @@ type remotesTable struct{}
 // RemotesSchema is the schema for the remotes table.
 var RemotesSchema = sql.Schema{
 	{Name: "repository_id", Type: sql.Text, Nullable: false, Source: RemotesTableName},
-	{Name: "name", Type: sql.Text, Nullable: false, Source: RemotesTableName},
-	{Name: "push_url", Type: sql.Text, Nullable: false, Source: RemotesTableName},
-	{Name: "fetch_url", Type: sql.Text, Nullable: false, Source: RemotesTableName},
-	{Name: "push_refspec", Type: sql.Text, Nullable: false, Source: RemotesTableName},
-	{Name: "fetch_refspec", Type: sql.Text, Nullable: false, Source: RemotesTableName},
+	{Name: "remote_name", Type: sql.Text, Nullable: false, Source: RemotesTableName},
+	{Name: "remote_push_url", Type: sql.Text, Nullable: false, Source: RemotesTableName},
+	{Name: "remote_fetch_url", Type: sql.Text, Nullable: false, Source: RemotesTableName},
+	{Name: "remote_push_refspec", Type: sql.Text, Nullable: false, Source: RemotesTableName},
+	{Name: "remote_fetch_refspec", Type: sql.Text, Nullable: false, Source: RemotesTableName},
 }
 
 var _ sql.PushdownProjectionAndFiltersTable = (*remotesTable)(nil)

--- a/repositories.go
+++ b/repositories.go
@@ -10,7 +10,7 @@ type repositoriesTable struct{}
 
 // RepositoriesSchema is the schema for the repositories table.
 var RepositoriesSchema = sql.Schema{
-	{Name: "id", Type: sql.Text, Nullable: false, Source: RepositoriesTableName},
+	{Name: "repository_id", Type: sql.Text, Nullable: false, Source: RepositoriesTableName},
 }
 
 var _ sql.PushdownProjectionAndFiltersTable = (*repositoriesTable)(nil)

--- a/tree_entries_test.go
+++ b/tree_entries_test.go
@@ -61,7 +61,7 @@ func TestTreeEntriesPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(3, sql.Text, TreeEntriesTableName, "name", false),
+			expression.NewGetFieldWithTable(4, sql.Text, TreeEntriesTableName, "tree_entry_name", false),
 			expression.NewLiteral("go/example.go", sql.Text),
 		),
 	})
@@ -73,7 +73,7 @@ func TestTreeEntriesPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(1, sql.Text, TreeEntriesTableName, "entry_hash", false),
+			expression.NewGetFieldWithTable(2, sql.Text, TreeEntriesTableName, "blob_hash", false),
 			expression.NewLiteral("880cd14280f4b9b6ed3986d6671f907d7cc2a198", sql.Text),
 		),
 	})
@@ -85,7 +85,7 @@ func TestTreeEntriesPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(3, sql.Text, TreeEntriesTableName, "name", false),
+			expression.NewGetFieldWithTable(4, sql.Text, TreeEntriesTableName, "tree_entry_name", false),
 			expression.NewLiteral("not_exists.json", sql.Text),
 		),
 	})
@@ -97,11 +97,11 @@ func TestTreeEntriesPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(0, sql.Text, TreeEntriesTableName, "tree_hash", false),
+			expression.NewGetFieldWithTable(1, sql.Text, TreeEntriesTableName, "tree_hash", false),
 			expression.NewLiteral("fb72698cab7617ac416264415f13224dfd7a165e", sql.Text),
 		),
 		expression.NewRegexp(
-			expression.NewGetFieldWithTable(3, sql.Text, TreeEntriesTableName, "name", false),
+			expression.NewGetFieldWithTable(4, sql.Text, TreeEntriesTableName, "tree_entry_name", false),
 			expression.NewLiteral(`\.go$`, sql.Text),
 		),
 	})
@@ -113,7 +113,7 @@ func TestTreeEntriesPushdown(t *testing.T) {
 
 	iter, err = table.WithProjectAndFilters(session, nil, []sql.Expression{
 		expression.NewEquals(
-			expression.NewGetFieldWithTable(0, sql.Text, TreeEntriesTableName, "tree_hash", false),
+			expression.NewGetFieldWithTable(1, sql.Text, TreeEntriesTableName, "tree_hash", false),
 			expression.NewLiteral("4d081c50e250fa32ea8b1313cf8bb7c2ad7627fd", sql.Text),
 		),
 	})


### PR DESCRIPTION
Closes #265 
Closes #266 
Closes #267 

This PR just renames the columns and adds the new ones for all tables to make the current things work. In a subsequent PR I will add the new iterators and matching possibilities, since now a lot more squashes can be done.

Partially solves #268, #264, #263