### PR TITLE
gitbase: support for unpacked objects, integration tests added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ addons:
     - gcc-6
     - g++-6
 
+before_install:
+  - docker pull pilosa/pilosa:v0.9.0
+  - docker run -d --name pilosa -p 127.0.0.1:10101:10101 pilosa/pilosa:v0.9.0
+  - docker ps -a
+
 install:
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90

--- a/index_test.go
+++ b/index_test.go
@@ -56,11 +56,7 @@ func assertIndexKeyValueIter(t *testing.T, iter sql.IndexKeyValueIter, expected 
 	}
 
 	require.NoError(iter.Close())
-	require.Equal(len(expected), len(result), "size does not match")
-
-	for i, r := range result {
-		require.Equal(expected[i], r, "at position %d", i)
-	}
+	require.ElementsMatch(expected, result)
 }
 
 func tableIndexValues(t *testing.T, table Indexable, ctx *sql.Context) sql.IndexValueIter {

--- a/packfiles.go
+++ b/packfiles.go
@@ -1,9 +1,8 @@
 package gitbase
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
+	stdioutil "io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -12,12 +11,14 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit"
+	"gopkg.in/src-d/go-git.v4/utils/ioutil"
 
 	"gopkg.in/src-d/go-billy-siva.v4"
 	billy "gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/osfs"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/idxfile"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/objfile"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
 )
 
@@ -50,7 +51,10 @@ type packfileIndex struct {
 	idx      *packfile.Index
 }
 
-type repositoryIndex []*packfileIndex
+type repositoryIndex struct {
+	dir     *dotgit.DotGit
+	indexes []*packfileIndex
+}
 
 func newRepositoryIndex(path string, kind repoKind) (*repositoryIndex, error) {
 	dot, packfiles, err := repositoryPackfiles(path, kind)
@@ -58,17 +62,17 @@ func newRepositoryIndex(path string, kind repoKind) (*repositoryIndex, error) {
 		return nil, err
 	}
 
-	var result repositoryIndex
+	ri := &repositoryIndex{dir: dot}
 	for _, p := range packfiles {
 		idx, err := openPackfileIndex(dot, p)
 		if err != nil {
 			return nil, err
 		}
 
-		result = append(result, &packfileIndex{p, idx})
+		ri.indexes = append(ri.indexes, &packfileIndex{p, idx})
 	}
 
-	return &result, nil
+	return ri, nil
 }
 
 func openPackfileIndex(
@@ -91,20 +95,42 @@ func openPackfileIndex(
 
 var errHashNotInIndex = errors.NewKind("object hash %s is not in repository")
 
-func (i repositoryIndex) find(hash plumbing.Hash) (int64, plumbing.Hash, error) {
-	for _, idx := range i {
+func (i *repositoryIndex) find(hash plumbing.Hash) (int64, plumbing.Hash, error) {
+	for _, idx := range i.indexes {
 		if entry, ok := idx.idx.LookupHash(hash); ok {
 			return int64(entry.Offset), idx.packfile, nil
 		}
 	}
-	return 0, plumbing.NewHash(""), errHashNotInIndex.New(hash)
+
+	ok, err := i.isUnpacked(hash)
+	if err != nil || ok {
+		return -1, plumbing.ZeroHash, err
+	}
+
+	return -1, plumbing.ZeroHash, errHashNotInIndex.New(hash)
+}
+
+func (i *repositoryIndex) isUnpacked(hash plumbing.Hash) (bool, error) {
+	f, err := i.dir.Object(hash)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+	if err := f.Close(); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 func repoFilesystem(path string, kind repoKind) (billy.Filesystem, error) {
 	if kind == sivaRepo {
 		localfs := osfs.New(filepath.Dir(path))
 
-		tmpDir, err := ioutil.TempDir(os.TempDir(), "gitbase-siva")
+		tmpDir, err := stdioutil.TempDir(os.TempDir(), "gitbase-siva")
 		if err != nil {
 			return nil, err
 		}
@@ -130,214 +156,7 @@ func findDotGit(fs billy.Filesystem) (billy.Filesystem, error) {
 	return fs, nil
 }
 
-type objectIter struct {
-	packs       *packIter
-	packObjects *packObjectIter
-}
-
-func newObjectIter(
-	pool *RepositoryPool,
-	typ plumbing.ObjectType,
-) *objectIter {
-	return &objectIter{packs: newPackIter(pool, typ)}
-}
-
-type encodedObject struct {
-	object.Object
-	RepositoryID string
-	Packfile     plumbing.Hash
-	Offset       uint64
-}
-
-func (i *objectIter) Next() (*encodedObject, error) {
-	for {
-		if i.packObjects == nil {
-			var err error
-			i.packObjects, err = i.packs.Next()
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		obj, offset, err := i.packObjects.Next()
-		if err != nil {
-			if err == io.EOF {
-				if err := i.packObjects.Close(); err != nil {
-					return nil, err
-				}
-
-				i.packObjects = nil
-				continue
-			}
-			return nil, err
-		}
-
-		return &encodedObject{
-			Object:       obj,
-			Offset:       offset,
-			RepositoryID: i.packs.repo.path,
-			Packfile:     i.packs.packfiles[i.packs.packpos-1],
-		}, nil
-	}
-}
-
-func (i *objectIter) Close() error {
-	if i.packObjects != nil {
-		return i.packObjects.Close()
-	}
-	return nil
-}
-
-type packIter struct {
-	typ  plumbing.ObjectType
-	pool *RepositoryPool
-	pos  int
-
-	repo *repository
-
-	storage   storer.EncodedObjectStorer
-	dotGit    *dotgit.DotGit
-	packfiles []plumbing.Hash
-	packpos   int
-}
-
-func newPackIter(pool *RepositoryPool, typ plumbing.ObjectType) *packIter {
-	return &packIter{pool: pool, typ: typ}
-}
-
-func (i *packIter) Next() (*packObjectIter, error) {
-	for {
-		if i.repo == nil {
-			if i.pos >= len(i.pool.repositories) {
-				return nil, io.EOF
-			}
-
-			repo := i.pool.repositories[i.pool.idOrder[i.pos]]
-			i.repo = &repo
-			i.pos++
-		}
-
-		if len(i.packfiles) == 0 {
-			var err error
-			i.dotGit, i.packfiles, err = repositoryPackfiles(i.repo.path, i.repo.kind)
-			if err != nil {
-				return nil, err
-			}
-			i.packpos = 0
-
-			storage, err := filesystem.NewObjectStorage(i.dotGit)
-			if err != nil {
-				return nil, err
-			}
-			i.storage = &storage
-		}
-
-		if i.packpos >= len(i.packfiles) {
-			i.packfiles = nil
-			i.repo = nil
-			continue
-		}
-
-		pf := i.packfiles[i.packpos]
-		i.packpos++
-
-		return newPackObjectIter(i.repo.path, i.dotGit, pf, i.storage, i.typ)
-	}
-}
-
-type packObjectIter struct {
-	hash    plumbing.Hash
-	close   func() error
-	idx     *idxfile.Idxfile
-	dec     *packfile.Decoder
-	pos     int
-	typ     plumbing.ObjectType
-	storage storer.EncodedObjectStorer
-}
-
-func newPackObjectIter(
-	path string,
-	dotGit *dotgit.DotGit,
-	hash plumbing.Hash,
-	storage storer.EncodedObjectStorer,
-	typ plumbing.ObjectType,
-) (*packObjectIter, error) {
-	packf, err := dotGit.ObjectPack(hash)
-	if err != nil {
-		return nil, err
-	}
-
-	idxf, err := dotGit.ObjectPackIdx(hash)
-	if err != nil {
-		return nil, err
-	}
-	defer idxf.Close()
-
-	i := idxfile.NewIdxfile()
-	if err := idxfile.NewDecoder(idxf).Decode(i); err != nil {
-		return nil, err
-	}
-
-	decoder, err := packfile.NewDecoder(packfile.NewScanner(packf), storage)
-	if err != nil {
-		return nil, err
-	}
-
-	return &packObjectIter{
-		hash:    hash,
-		idx:     i,
-		dec:     decoder,
-		typ:     typ,
-		storage: storage,
-		close:   func() error { return decoder.Close() },
-	}, nil
-}
-
-func (i *packObjectIter) Next() (object.Object, uint64, error) {
-	for {
-		if i.close != nil {
-			if err := i.close(); err != nil {
-				return nil, 0, err
-			}
-		}
-
-		if i.pos >= len(i.idx.Entries) {
-			return nil, 0, io.EOF
-		}
-
-		offset := i.idx.Entries[i.pos].Offset
-		i.pos++
-		obj, err := i.dec.DecodeObjectAt(int64(offset))
-		if err != nil {
-			return nil, 0, err
-		}
-
-		if obj.Type() != i.typ {
-			continue
-		}
-
-		decodedObj, err := object.DecodeObject(i.storage, obj)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		return decodedObj, offset, nil
-	}
-}
-
-func (i *packObjectIter) Close() error { return i.close() }
-
-type objectDecoder struct {
-	repo     string
-	packfile plumbing.Hash
-	decoder  *packfile.Decoder
-	storage  storer.EncodedObjectStorer
-}
-
-func newObjectDecoder(
-	repo repository,
-	hash plumbing.Hash,
-) (*objectDecoder, error) {
+func getUnpackedObject(repo repository, hash plumbing.Hash) (o object.Object, err error) {
 	fs, err := repoFilesystem(repo.path, repo.kind)
 	if err != nil {
 		return nil, err
@@ -348,8 +167,73 @@ func newObjectDecoder(
 		return nil, err
 	}
 
-	packfilePath := fs.Join("objects", "pack", fmt.Sprintf("pack-%s.pack", hash))
-	packf, err := fs.Open(packfilePath)
+	dot := dotgit.New(fs)
+
+	f, err := dot.Object(hash)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, plumbing.ErrObjectNotFound
+		}
+
+		return nil, err
+	}
+
+	defer ioutil.CheckClose(f, &err)
+
+	storage, err := filesystem.NewStorage(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	obj := storage.NewEncodedObject()
+	r, err := objfile.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	defer ioutil.CheckClose(r, &err)
+
+	t, size, err := r.Header()
+	if err != nil {
+		return nil, err
+	}
+
+	obj.SetType(t)
+	obj.SetSize(size)
+	w, err := obj.Writer()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = io.Copy(w, r)
+
+	o, err = object.DecodeObject(storage, obj)
+	return
+}
+
+type repoObjectDecoder struct {
+	repo     string
+	packfile plumbing.Hash
+	decoder  *packfile.Decoder
+	storage  storer.EncodedObjectStorer
+}
+
+func newRepoObjectDecoder(
+	repo repository,
+	hash plumbing.Hash,
+) (*repoObjectDecoder, error) {
+	fs, err := repoFilesystem(repo.path, repo.kind)
+	if err != nil {
+		return nil, err
+	}
+
+	fs, err = findDotGit(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	dot := dotgit.New(fs)
+	packf, err := dot.ObjectPack(hash)
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +250,7 @@ func newObjectDecoder(
 		return nil, err
 	}
 
-	return &objectDecoder{
+	return &repoObjectDecoder{
 		repo:     repo.path,
 		packfile: hash,
 		decoder:  decoder,
@@ -374,17 +258,55 @@ func newObjectDecoder(
 	}, nil
 }
 
-func (d *objectDecoder) equals(repo string, packfile plumbing.Hash) bool {
+func (d *repoObjectDecoder) equals(repo string, packfile plumbing.Hash) bool {
 	return d.repo == repo && d.packfile == packfile
 }
 
-func (d *objectDecoder) get(offset int64) (object.Object, error) {
+func (d *repoObjectDecoder) get(offset int64) (object.Object, error) {
 	encodedObj, err := d.decoder.DecodeObjectAt(offset)
 	if err != nil {
 		return nil, err
 	}
 
 	return object.DecodeObject(d.storage, encodedObj)
+}
+
+func (d *repoObjectDecoder) Close() error { return d.decoder.Close() }
+
+type objectDecoder struct {
+	pool    *RepositoryPool
+	decoder *repoObjectDecoder
+}
+
+func newObjectDecoder(pool *RepositoryPool) *objectDecoder {
+	return &objectDecoder{pool: pool}
+}
+
+func (d *objectDecoder) decode(
+	repository string,
+	packfile plumbing.Hash,
+	offset int64,
+	hash plumbing.Hash,
+) (object.Object, error) {
+	if offset >= 0 {
+		if d.decoder == nil || !d.decoder.equals(repository, packfile) {
+			if d.decoder != nil {
+				if err := d.decoder.Close(); err != nil {
+					return nil, err
+				}
+			}
+
+			var err error
+			d.decoder, err = newRepoObjectDecoder(d.pool.repositories[repository], packfile)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return d.decoder.get(offset)
+	}
+
+	return getUnpackedObject(d.pool.repositories[repository], hash)
 }
 
 func (d *objectDecoder) Close() error { return d.decoder.Close() }

--- a/remotes.go
+++ b/remotes.go
@@ -279,7 +279,11 @@ type remotesIndexIter struct {
 }
 
 func (i *remotesIndexIter) Next() (sql.Row, error) {
-	data, err := i.index.Next()
+	var err error
+	var data []byte
+	defer closeIndexOnError(&err, i.index)
+
+	data, err = i.index.Next()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds support for unpacked objects, which made the index contain different objects and not match the result of the query without indexes.
A bunch of integration tests for indexes of all tables testing they output the exact same thing as the same query without indexes have been added as well.

Because it's super important to ensure the index is closed so it can be released, each index iterator has now a call to `closeIndexOnError`, which closes the index if there is an error or EOF in an iterator, ensure it's *always* closed.

After this is merged, `feature/indexable` is ready to be PR'd and merged to master.