### PR TITLE
 gitbase: update benchmarks with indexes 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -454,7 +454,7 @@
     "sql/parse",
     "sql/plan"
   ]
-  revision = "22325c6e91f9d632f846c3c0633278dfd24eae86"
+  revision = "953d1586f8b2558d38ca28e649a30819f6b2b5f4"
 
 [[projects]]
   name = "gopkg.in/src-d/go-siva.v1"
@@ -507,6 +507,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d3cdcffe6b336f24d0c3a302b110f5993fbab1b6759278556c79c96da483aa35"
+  inputs-digest = "3eeef3a5f1edb8ca8289c16ab2985daabab2eead487cfd192c36c81e428d4dd3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "gopkg.in/src-d/go-mysql-server.v0"
-  revision = "22325c6e91f9d632f846c3c0633278dfd24eae86"
+  revision = "953d1586f8b2558d38ca28e649a30819f6b2b5f4"
 
 [[constraint]]
   name = "github.com/jessevdk/go-flags"

--- a/integration_test.go
+++ b/integration_test.go
@@ -321,6 +321,22 @@ func BenchmarkQueries(b *testing.B) {
 			ON r.repository_id = rr.repository_id`,
 		},
 		{
+			"select by specific id",
+			`SELECT * FROM ref_commits r
+			INNER JOIN commits c
+				ON c.commit_hash = r.commit_hash
+			WHERE c.commit_hash = '6ecf0ef2c2dffb796033e5a02219af86ec6584e5'
+				AND r.ref_name = 'refs/heads/master'`,
+		},
+		{
+			"select file by name",
+			`SELECT * FROM files WHERE file_path = 'LICENSE'`,
+		},
+		{
+			"select files by language",
+			`SELECT * FROM files WHERE language(file_path, blob_content) = 'Go'`,
+		},
+		{
 			"query with commit_blobs",
 			`SELECT COUNT(c.commit_hash), c.commit_hash
 			FROM ref_commits r
@@ -336,9 +352,9 @@ func BenchmarkQueries(b *testing.B) {
 			FROM (
 				SELECT YEAR(c.commit_author_when) AS first_commit_year
 				FROM ref_commits r
-				INNER JOIN commits c 
+				INNER JOIN commits c
 					ON r.commit_hash = c.commit_hash
-				ORDER BY c.commit_author_when 
+				ORDER BY c.commit_author_when
 				LIMIT 1
 			) repo_years
 			GROUP BY first_commit_year`,
@@ -369,7 +385,7 @@ func BenchmarkQueries(b *testing.B) {
 		{
 			"join refs and blobs",
 			`SELECT * FROM refs r
-			INNER JOIN commit_blobs cb 
+			INNER JOIN commit_blobs cb
 				ON r.commit_hash = cb.commit_hash
 			INNER JOIN blobs b
 				ON cb.blob_hash = b.blob_hash`,
@@ -377,7 +393,7 @@ func BenchmarkQueries(b *testing.B) {
 		{
 			"join refs and blobs with filters",
 			`SELECT * FROM refs r
-			INNER JOIN commit_blobs cb 
+			INNER JOIN commit_blobs cb
 				ON r.commit_hash = cb.commit_hash
 			INNER JOIN blobs b
 				ON cb.blob_hash = b.blob_hash
@@ -385,34 +401,56 @@ func BenchmarkQueries(b *testing.B) {
 		},
 	}
 
+	indexesEngine, pool, cleanup := setup(b)
+	defer cleanup()
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "pilosa-idx-gitbase")
+	require.NoError(b, err)
+	defer os.RemoveAll(tmpDir)
+	indexesEngine.Catalog.RegisterIndexDriver(pilosa.NewIndexDriver(tmpDir))
+
+	ctx := sql.NewContext(
+		context.TODO(),
+		sql.WithSession(gitbase.NewSession(pool)),
+	)
+
+	engine := sqle.New()
+	engine.AddDatabase(gitbase.NewDatabase("foo"))
+	engine.Catalog.RegisterFunctions(function.Functions)
+
+	squashEngine := sqle.New()
+	squashEngine.AddDatabase(gitbase.NewDatabase("foo"))
+	squashEngine.Catalog.RegisterFunctions(function.Functions)
+	squashEngine.Analyzer.AddRule(rule.SquashJoinsRule, rule.SquashJoins)
+
+	cleanupIndexes := createTestIndexes(b, indexesEngine, ctx)
+	defer cleanupIndexes()
+
 	for _, qq := range queries {
 		b.Run(qq.name, func(b *testing.B) {
-			benchmarkQuery(b, qq.query)
+			b.Run("base", func(b *testing.B) {
+				benchmarkQuery(b, qq.query, engine, ctx)
+			})
+
+			b.Run("indexes", func(b *testing.B) {
+				benchmarkQuery(b, qq.query, indexesEngine, ctx)
+			})
+
+			b.Run("squash", func(b *testing.B) {
+				benchmarkQuery(b, qq.query, squashEngine, ctx)
+			})
 		})
 	}
 }
 
-func benchmarkQuery(b *testing.B, query string) {
-	engine, pool, cleanup := setup(b)
-	defer cleanup()
+func benchmarkQuery(b *testing.B, query string, engine *sqle.Engine, ctx *sql.Context) {
+	for i := 0; i < b.N; i++ {
+		_, rows, err := engine.Query(ctx, query)
+		require.NoError(b, err)
 
-	session := gitbase.NewSession(pool)
-	ctx := sql.NewContext(context.TODO(), sql.WithSession(session))
-
-	run := func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, rows, err := engine.Query(ctx, query)
-			require.NoError(b, err)
-
-			_, err = sql.RowIterToRows(rows)
-			require.NoError(b, err)
-		}
+		_, err = sql.RowIterToRows(rows)
+		require.NoError(b, err)
 	}
-
-	b.Run("no squash", run)
-
-	engine.Analyzer.AddRule(rule.SquashJoinsRule, rule.SquashJoins)
-	b.Run("squash", run)
 }
 
 func TestIndexes(t *testing.T) {
@@ -429,89 +467,17 @@ func TestIndexes(t *testing.T) {
 		sql.WithSession(gitbase.NewSession(pool)),
 	)
 
-	db, err := engine.Catalog.Database("foo")
-	require.NoError(t, err)
-	tables := db.Tables()
-
 	baseEngine := sqle.New()
 	baseEngine.AddDatabase(gitbase.NewDatabase("foo"))
 	baseEngine.Catalog.RegisterFunctions(function.Functions)
 
-	var indexes = []indexData{
-		{
-			table:   tables[gitbase.ReferencesTableName],
-			columns: []string{"ref_name"},
-			expressions: []sql.Expression{
-				col(t, gitbase.RefsSchema, "ref_name"),
-			},
-		},
-		{
-			table:   tables[gitbase.RemotesTableName],
-			columns: []string{"remote_name"},
-			expressions: []sql.Expression{
-				col(t, gitbase.RemotesSchema, "remote_name"),
-			},
-		},
-		{
-			table:   tables[gitbase.RefCommitsTableName],
-			columns: []string{"ref_name"},
-			expressions: []sql.Expression{
-				col(t, gitbase.RefCommitsSchema, "ref_name"),
-			},
-		},
-		{
-			table:   tables[gitbase.CommitsTableName],
-			columns: []string{"commit_author_email"},
-			expressions: []sql.Expression{
-				col(t, gitbase.CommitsSchema, "commit_author_email"),
-			},
-		},
-		{
-			table:   tables[gitbase.CommitTreesTableName],
-			columns: []string{"commit_hash"},
-			expressions: []sql.Expression{
-				col(t, gitbase.CommitTreesSchema, "commit_hash"),
-			},
-		},
-		{
-			table:   tables[gitbase.CommitBlobsTableName],
-			columns: []string{"commit_hash"},
-			expressions: []sql.Expression{
-				col(t, gitbase.CommitBlobsSchema, "commit_hash"),
-			},
-		},
-		{
-			table:   tables[gitbase.TreeEntriesTableName],
-			columns: []string{"tree_entry_name"},
-			expressions: []sql.Expression{
-				col(t, gitbase.TreeEntriesSchema, "tree_entry_name"),
-			},
-		},
-		{
-			table:   tables[gitbase.BlobsTableName],
-			columns: []string{"blob_hash"},
-			expressions: []sql.Expression{
-				col(t, gitbase.BlobsSchema, "blob_hash"),
-			},
-		},
-		{
-			table:   tables[gitbase.FilesTableName],
-			columns: []string{"file_path"},
-			expressions: []sql.Expression{
-				col(t, gitbase.FilesSchema, "file_path"),
-			},
-		},
-	}
-
-	for _, idx := range indexes {
-		createIndex(t, engine, idx, ctx)
-		defer deleteIndex(t, engine, idx)
-	}
+	cleanupIndexes := createTestIndexes(t, engine, ctx)
+	defer cleanupIndexes()
 
 	testCases := []string{
 		`SELECT ref_name, commit_hash FROM refs WHERE ref_name = 'refs/heads/master'`,
 		`SELECT remote_name, remote_push_url FROM remotes WHERE remote_name = 'origin'`,
-		`SELECT commit_hash, commit_author_email FROM commits WHERE commit_author_email = 'mcuadros@gmail.com'`,
+		`SELECT commit_hash, commit_author_email FROM commits WHERE commit_hash = '918c48b83bd081e863dbe1b80f8998f058cd8294'`,
 		`SELECT commit_hash, ref_name FROM ref_commits WHERE ref_name = 'refs/heads/master'`,
 		`SELECT commit_hash, tree_hash FROM commit_trees WHERE commit_hash = '918c48b83bd081e863dbe1b80f8998f058cd8294'`,
 		`SELECT commit_hash, blob_hash FROM commit_blobs WHERE commit_hash = '918c48b83bd081e863dbe1b80f8998f058cd8294'`,
@@ -541,7 +507,7 @@ func TestIndexes(t *testing.T) {
 	}
 }
 
-func col(t *testing.T, schema sql.Schema, name string) sql.Expression {
+func col(t testing.TB, schema sql.Schema, name string) sql.Expression {
 	for i, col := range schema {
 		if col.Name == name {
 			return expression.NewGetFieldWithTable(i, col.Type, col.Source, col.Name, col.Nullable)
@@ -553,9 +519,115 @@ func col(t *testing.T, schema sql.Schema, name string) sql.Expression {
 }
 
 type indexData struct {
+	id          string
 	expressions []sql.Expression
 	table       sql.Table
 	columns     []string
+}
+
+func createTestIndexes(t testing.TB, engine *sqle.Engine, ctx *sql.Context) func() {
+	db, err := engine.Catalog.Database("foo")
+	require.NoError(t, err)
+	tables := db.Tables()
+
+	var indexes = []indexData{
+		{
+			id:      "refs_idx",
+			table:   tables[gitbase.ReferencesTableName],
+			columns: []string{"ref_name"},
+			expressions: []sql.Expression{
+				col(t, gitbase.RefsSchema, "ref_name"),
+			},
+		},
+		{
+			id:      "remotes_idx",
+			table:   tables[gitbase.RemotesTableName],
+			columns: []string{"remote_name"},
+			expressions: []sql.Expression{
+				col(t, gitbase.RemotesSchema, "remote_name"),
+			},
+		},
+		{
+			id:      "ref_commits_idx",
+			table:   tables[gitbase.RefCommitsTableName],
+			columns: []string{"ref_name"},
+			expressions: []sql.Expression{
+				col(t, gitbase.RefCommitsSchema, "ref_name"),
+			},
+		},
+		{
+			id:      "commits_idx",
+			table:   tables[gitbase.CommitsTableName],
+			columns: []string{"commit_hash"},
+			expressions: []sql.Expression{
+				col(t, gitbase.CommitsSchema, "commit_hash"),
+			},
+		},
+		{
+			id:      "commit_trees_idx",
+			table:   tables[gitbase.CommitTreesTableName],
+			columns: []string{"commit_hash"},
+			expressions: []sql.Expression{
+				col(t, gitbase.CommitTreesSchema, "commit_hash"),
+			},
+		},
+		{
+			id:      "commit_blobs_idx",
+			table:   tables[gitbase.CommitBlobsTableName],
+			columns: []string{"commit_hash"},
+			expressions: []sql.Expression{
+				col(t, gitbase.CommitBlobsSchema, "commit_hash"),
+			},
+		},
+		{
+			id:      "tree_entries_idx",
+			table:   tables[gitbase.TreeEntriesTableName],
+			columns: []string{"tree_entry_name"},
+			expressions: []sql.Expression{
+				col(t, gitbase.TreeEntriesSchema, "tree_entry_name"),
+			},
+		},
+		{
+			id:      "blobs_idx",
+			table:   tables[gitbase.BlobsTableName],
+			columns: []string{"blob_hash"},
+			expressions: []sql.Expression{
+				col(t, gitbase.BlobsSchema, "blob_hash"),
+			},
+		},
+		{
+			id:      "files_idx",
+			table:   tables[gitbase.FilesTableName],
+			columns: []string{"file_path"},
+			expressions: []sql.Expression{
+				col(t, gitbase.FilesSchema, "file_path"),
+			},
+		},
+		{
+			id:      "files_lang_idx",
+			table:   tables[gitbase.FilesTableName],
+			columns: []string{"file_path"},
+			expressions: []sql.Expression{
+				func() sql.Expression {
+					f, _ := function.NewLanguage(
+						col(t, gitbase.FilesSchema, "file_path"),
+						col(t, gitbase.FilesSchema, "blob_content"),
+					)
+					return f
+				}(),
+			},
+		},
+	}
+
+	for _, idx := range indexes {
+		createIndex(t, engine, idx, ctx)
+	}
+
+	return func() {
+		for _, idx := range indexes {
+			defer deleteIndex(t, engine, idx)
+		}
+	}
 }
 
 func createIndex(
@@ -576,7 +648,7 @@ func createIndex(
 
 	idx, err := driver.Create(
 		"foo", data.table.Name(),
-		data.table.Name()+"_idx", hashes,
+		data.id, hashes,
 		make(map[string]string),
 	)
 	require.NoError(err)
@@ -598,7 +670,7 @@ func deleteIndex(
 	data indexData,
 ) {
 	t.Helper()
-	done, err := e.Catalog.DeleteIndex("foo", data.table.Name()+"_idx")
+	done, err := e.Catalog.DeleteIndex("foo", data.id)
 	require.NoError(t, err)
 	<-done
 }

--- a/packfiles.go
+++ b/packfiles.go
@@ -271,7 +271,9 @@ func (d *repoObjectDecoder) get(offset int64) (object.Object, error) {
 	return object.DecodeObject(d.storage, encodedObj)
 }
 
-func (d *repoObjectDecoder) Close() error { return d.decoder.Close() }
+func (d *repoObjectDecoder) Close() error {
+	return d.decoder.Close()
+}
 
 type objectDecoder struct {
 	pool    *RepositoryPool
@@ -309,4 +311,9 @@ func (d *objectDecoder) decode(
 	return getUnpackedObject(d.pool.repositories[repository], hash)
 }
 
-func (d *objectDecoder) Close() error { return d.decoder.Close() }
+func (d *objectDecoder) Close() error {
+	if d.decoder != nil {
+		return d.decoder.Close()
+	}
+	return nil
+}

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/analyzer/analyzer.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/analyzer/analyzer.go
@@ -101,7 +101,7 @@ func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node) (sql.Node, error) {
 		return nil, err
 	}
 
-	for i := 0; !reflect.DeepEqual(prev, cur); {
+	for i := 0; !nodesEqual(prev, cur); {
 		a.Log("previous node does not match new node, analyzing again, iteration: %d", i)
 		prev = cur
 		cur, err = a.analyzeOnce(ctx, cur)
@@ -165,4 +165,20 @@ func (a *Analyzer) validateOnce(ctx *sql.Context, n sql.Node) (validationErrors 
 	}
 
 	return validationErrors
+}
+
+type equaler interface {
+	Equal(sql.Node) bool
+}
+
+func nodesEqual(a, b sql.Node) bool {
+	if e, ok := a.(equaler); ok {
+		return e.Equal(b)
+	}
+
+	if e, ok := b.(equaler); ok {
+		return e.Equal(a)
+	}
+
+	return reflect.DeepEqual(a, b)
 }


### PR DESCRIPTION
Depends on #308 and https://github.com/src-d/go-mysql-server/pull/218/files

Results:

```
go test -run='^$' -bench=. -benchmem
goos: darwin
goarch: amd64
pkg: github.com/src-d/gitbase
BenchmarkQueries/simple_query/base-4                 500           2725531 ns/op          570099 B/op       3405 allocs/op
BenchmarkQueries/simple_query/indexes-4              500           2383330 ns/op          570077 B/op       3404 allocs/op
BenchmarkQueries/simple_query/squash-4              1000           1217884 ns/op          252379 B/op       1526 allocs/op
BenchmarkQueries/select_by_specific_id/base-4                100          13601108 ns/op         2815530 B/op      18485 allocs/op
BenchmarkQueries/select_by_specific_id/indexes-4              30          44128295 ns/op         2296652 B/op      19293 allocs/op
BenchmarkQueries/select_by_specific_id/squash-4              200           6174956 ns/op         3700659 B/op       8138 allocs/op
BenchmarkQueries/select_file_by_name/base-4                   50          20476010 ns/op         9402706 B/op       8540 allocs/op
BenchmarkQueries/select_file_by_name/indexes-4               300           4335838 ns/op          404237 B/op       3476 allocs/op
BenchmarkQueries/select_file_by_name/squash-4                 50          20370002 ns/op         9396318 B/op       8546 allocs/op
BenchmarkQueries/select_files_by_language/base-4              50          23792727 ns/op        12234130 B/op      10646 allocs/op
BenchmarkQueries/select_files_by_language/indexes-4                  500           3040444 ns/op          245770 B/op 1772 allocs/op
BenchmarkQueries/select_files_by_language/squash-4                    50          27257689 ns/op        12227982 B/op10663 allocs/op
BenchmarkQueries/query_with_commit_blobs/base-4                        1        1120721888 ns/op        506874984 B/op    501091 allocs/op
BenchmarkQueries/query_with_commit_blobs/indexes-4                     1        1101141586 ns/op        506794936 B/op    501143 allocs/op
BenchmarkQueries/query_with_commit_blobs/squash-4                     50          20050871 ns/op        10417798 B/op13527 allocs/op
BenchmarkQueries/query_with_history_idx_and_3_joins/base-4            10         169818729 ns/op        57151502 B/op     138446 allocs/op
BenchmarkQueries/query_with_history_idx_and_3_joins/indexes-4                 10         168895475 ns/op        57169314 B/op        138452 allocs/op
BenchmarkQueries/query_with_history_idx_and_3_joins/squash-4                 200           6441617 ns/op         3964290 B/op         10138 allocs/op
BenchmarkQueries/query_with_history_idx/base-4                                10         167978639 ns/op        57065468 B/op        138221 allocs/op
BenchmarkQueries/query_with_history_idx/indexes-4                             10         173694789 ns/op        57062017 B/op        138218 allocs/op
BenchmarkQueries/query_with_history_idx/squash-4                             200           6512084 ns/op         3936113 B/op         10075 allocs/op
BenchmarkQueries/join_tree_entries_and_blobs/base-4                            5         268234044 ns/op        153164390 B/op       142350 allocs/op
BenchmarkQueries/join_tree_entries_and_blobs/indexes-4                         5         261925411 ns/op        153051513 B/op       142335 allocs/op
BenchmarkQueries/join_tree_entries_and_blobs/squash-4                        100          15682064 ns/op         5906237 B/op          7012 allocs/op
BenchmarkQueries/join_tree_entries_and_blobs_with_filters/base-4              30          44165301 ns/op        22904766 B/op         24492 allocs/op
BenchmarkQueries/join_tree_entries_and_blobs_with_filters/indexes-4           30          42424042 ns/op        21944932 B/op         23979 allocs/op
BenchmarkQueries/join_tree_entries_and_blobs_with_filters/squash-4           300           4958507 ns/op         1942901 B/op          5050 allocs/op
BenchmarkQueries/join_refs_and_blobs/base-4                                    3         368585376 ns/op        178222346 B/op       165070 allocs/op
BenchmarkQueries/join_refs_and_blobs/indexes-4                                 3         336790993 ns/op        178360354 B/op       165088 allocs/op
BenchmarkQueries/join_refs_and_blobs/squash-4                                 50          22020730 ns/op        10710406 B/op          8786 allocs/op
BenchmarkQueries/join_refs_and_blobs_with_filters/base-4                      10         134658444 ns/op        48741762 B/op         47078 allocs/op
BenchmarkQueries/join_refs_and_blobs_with_filters/indexes-4                   10         109242054 ns/op        48696253 B/op         47324 allocs/op
BenchmarkQueries/join_refs_and_blobs_with_filters/squash-4                   300           5756875 ns/op         3020239 B/op          4400 allocs/op
PASS
ok      github.com/src-d/gitbase        55.915s
```