### PR TITLE
internal/rule: fix squashjoins rule to squash projections properly too

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -132,6 +132,17 @@ func TestIntegration(t *testing.T) {
 				{int32(4), "b029517f6300c2da0f4b651b8642506cd6aaf45d"},
 			},
 		},
+		{
+			`SELECT count(1), refs.repository_id
+				FROM refs
+				NATURAL JOIN commits
+				NATURAL JOIN commit_blobs
+				WHERE refs.ref_name = 'HEAD'
+				GROUP BY refs.repository_id`,
+			[]sql.Row{
+				{int32(9), "worktree"},
+			},
+		},
 	}
 
 	runTests := func(t *testing.T) {

--- a/internal/rule/squashjoins.go
+++ b/internal/rule/squashjoins.go
@@ -31,6 +31,9 @@ func SquashJoins(
 	defer span.Finish()
 
 	a.Log("squashing joins, node of type %T", n)
+
+	projectSquashes := countProjectSquashes(n)
+
 	n, err := n.TransformUp(func(n sql.Node) (sql.Node, error) {
 		join, ok := n.(*plan.InnerJoin)
 		if !ok {
@@ -39,11 +42,12 @@ func SquashJoins(
 
 		return squashJoin(join)
 	})
+
 	if err != nil {
 		return nil, err
 	}
 
-	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+	n, err = n.TransformUp(func(n sql.Node) (sql.Node, error) {
 		t, ok := n.(*joinedTables)
 		if !ok {
 			return n, nil
@@ -51,6 +55,90 @@ func SquashJoins(
 
 		return buildSquashedTable(t.tables, t.filters, t.columns, t.indexes)
 	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+		if projectSquashes <= 0 {
+			return n, nil
+		}
+
+		project, ok := n.(*plan.Project)
+		if !ok {
+			return n, nil
+		}
+
+		child, ok := project.Child.(*plan.Project)
+		if !ok {
+			return n, nil
+		}
+
+		squashedProject, err := squashProjects(project, child)
+		if err != nil {
+			return nil, err
+		}
+
+		projectSquashes--
+		return squashedProject, nil
+	})
+}
+
+func countProjectSquashes(n sql.Node) int {
+	var squashableProjects int
+	plan.Inspect(n, func(node sql.Node) bool {
+		if project, ok := node.(*plan.Project); ok {
+			if _, ok := project.Child.(*plan.InnerJoin); ok {
+				squashableProjects++
+			}
+		}
+
+		return true
+	})
+
+	return squashableProjects - 1
+}
+
+// ErrWrongProjection is raised if a plan.Project node contains a wrong expression.
+var ErrWrongProjection = errors.NewKind("wrong expression found in project node %s")
+
+func squashProjects(parent, child *plan.Project) (sql.Node, error) {
+	projections := []sql.Expression{}
+	for _, expr := range parent.Expressions() {
+		parentField, ok := expr.(*expression.GetField)
+		if !ok {
+			return nil, ErrWrongProjection.New(parent.String())
+		}
+
+		index := parentField.Index()
+		for _, e := range child.Expressions() {
+			childField, ok := e.(*expression.GetField)
+			if !ok {
+				return nil, ErrWrongProjection.New(child.String())
+			}
+
+			if referenceSameColumn(parentField, childField) {
+				index = childField.Index()
+			}
+		}
+
+		projection := expression.NewGetFieldWithTable(
+			index,
+			parentField.Type(),
+			parentField.Table(),
+			parentField.Name(),
+			parentField.IsNullable(),
+		)
+
+		projections = append(projections, projection)
+	}
+
+	return plan.NewProject(projections, child.Child), nil
+}
+
+func referenceSameColumn(parent, child *expression.GetField) bool {
+	return parent.Name() == child.Name() && parent.Table() == child.Table()
 }
 
 func squashJoin(join *plan.InnerJoin) (sql.Node, error) {


### PR DESCRIPTION
Fixes #322 

The bug came because the projects nodes over inner joins weren't squashed, so they stayed chained and pointing to wrong field indexes after the table squashing
```
GroupBy
 ├─ Aggregate(COUNT(1), refs.repository_id)
 ├─ Grouping(refs.repository_id)
 └─ Project(refs.repository_id, refs.commit_hash, refs.ref_name, commits.commit_author_name, commits.commit_author_email, commits.commit_author_when, commits.committer_name, commits.committer_email, commits.committer_when, commits.commit_message, commits.tree_hash, commits.commit_parents, commit_blobs.blob_hash)
     └─ Project(refs.repository_id, refs.commit_hash, refs.ref_name, commits.commit_author_name, commits.commit_author_email, commits.commit_author_when, commits.committer_name, commits.committer_email, commits.committer_when, commits.commit_message, commits.tree_hash, commits.commit_parents)
         └─ Filter(refs.repository_id = commit_blobs.repository_id AND refs.commit_hash = commit_blobs.commit_hash)
             └─ SquashedTable(refs, commits, commit_blobs)
                 ├─ Columns
                 │   ├─ Column(repository_id, TEXT, nullable=false)
                 │   ├─ Column(ref_name, TEXT, nullable=false)
                 │   ├─ Column(commit_hash, TEXT, nullable=false)
                 │   ├─ Column(repository_id, TEXT, nullable=false)
                 │   ├─ Column(commit_hash, TEXT, nullable=false)
                 │   ├─ Column(commit_author_name, TEXT, nullable=false)
                 │   ├─ Column(commit_author_email, TEXT, nullable=false)
                 │   ├─ Column(commit_author_when, TIMESTAMP, nullable=false)
                 │   ├─ Column(committer_name, TEXT, nullable=false)
                 │   ├─ Column(committer_email, TEXT, nullable=false)
                 │   ├─ Column(committer_when, TIMESTAMP, nullable=false)
                 │   ├─ Column(commit_message, TEXT, nullable=false)
                 │   ├─ Column(tree_hash, TEXT, nullable=false)
                 │   ├─ Column(commit_parents, JSON, nullable=false)
                 │   ├─ Column(repository_id, TEXT, nullable=false)
                 │   ├─ Column(commit_hash, TEXT, nullable=false)
                 │   └─ Column(blob_hash, TEXT, nullable=false)
                 └─ Filters
                     ├─ refs.repository_id = commit_blobs.repository_id
                     ├─ refs.commit_hash = commit_blobs.commit_hash
                     ├─ refs.repository_id = commits.repository_id
                     ├─ refs.commit_hash = commits.commit_hash
                     └─ refs.ref_name = "HEAD"

```

Now the project nodes are squashed too, so it works properly:
```
GroupBy
 ├─ Aggregate(COUNT(1), refs.repository_id)
 ├─ Grouping(refs.repository_id)
 └─ Project(refs.repository_id, refs.commit_hash, refs.ref_name, commits.commit_author_name, commits.commit_author_email, commits.commit_author_when, commits.committer_name, commits.committer_email, commits.committer_when, commits.commit_message, commits.tree_hash, commits.commit_parents, commit_blobs.blob_hash)
     └─ Filter(refs.repository_id = commit_blobs.repository_id AND refs.commit_hash = commit_blobs.commit_hash)
         └─ SquashedTable(refs, commits, commit_blobs)
             ├─ Columns
             │   ├─ Column(repository_id, TEXT, nullable=false)
             │   ├─ Column(ref_name, TEXT, nullable=false)
             │   ├─ Column(commit_hash, TEXT, nullable=false)
             │   ├─ Column(repository_id, TEXT, nullable=false)
             │   ├─ Column(commit_hash, TEXT, nullable=false)
             │   ├─ Column(commit_author_name, TEXT, nullable=false)
             │   ├─ Column(commit_author_email, TEXT, nullable=false)
             │   ├─ Column(commit_author_when, TIMESTAMP, nullable=false)
             │   ├─ Column(committer_name, TEXT, nullable=false)
             │   ├─ Column(committer_email, TEXT, nullable=false)
             │   ├─ Column(committer_when, TIMESTAMP, nullable=false)
             │   ├─ Column(commit_message, TEXT, nullable=false)
             │   ├─ Column(tree_hash, TEXT, nullable=false)
             │   ├─ Column(commit_parents, JSON, nullable=false)
             │   ├─ Column(repository_id, TEXT, nullable=false)
             │   ├─ Column(commit_hash, TEXT, nullable=false)
             │   └─ Column(blob_hash, TEXT, nullable=false)
             └─ Filters
                 ├─ refs.repository_id = commit_blobs.repository_id
                 ├─ refs.commit_hash = commit_blobs.commit_hash
                 ├─ refs.repository_id = commits.repository_id
                 ├─ refs.commit_hash = commits.commit_hash
                 └─ refs.ref_name = "HEAD"

```


Signed-off-by: Manuel Carmona <manu.carmona90@gmail.com>