### PR TITLE
gitbase: custom encode and decode of index keys to save space

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -393,7 +393,7 @@ func (i *blobsKeyValueIter) Next() ([]interface{}, []byte, error) {
 			hash = blob.Hash.String()
 		}
 
-		key, err := encodeIndexKey(packOffsetIndexKey{
+		key, err := encodeIndexKey(&packOffsetIndexKey{
 			Repository: i.repo.ID,
 			Packfile:   packfile.String(),
 			Offset:     offset,

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -147,7 +147,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 
 	var expected = []keyValue{
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -158,7 +158,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     79864,
@@ -169,7 +169,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2418,
@@ -180,7 +180,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78932,
@@ -191,7 +191,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     82000,
@@ -202,7 +202,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     85438,
@@ -213,7 +213,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -224,7 +224,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     81707,
@@ -235,7 +235,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1752,
@@ -246,7 +246,7 @@ func TestBlobsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2436,

--- a/commit_files_test.go
+++ b/commit_files_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
@@ -77,4 +78,27 @@ func TestCommitFilesIndex(t *testing.T) {
 			expression.NewLiteral("af2d6a6954d532f8ffb47615169c8fdf9d383a1a", sql.Text),
 		)},
 	)
+}
+
+func TestEncodeCommitFileIndexKey(t *testing.T) {
+	require := require.New(t)
+
+	k := commitFileIndexKey{
+		Repository: "repo1",
+		Packfile:   plumbing.ZeroHash.String(),
+		Offset:     1234,
+		Hash:       plumbing.ZeroHash.String(),
+		Name:       "foo/bar.md",
+		Mode:       5,
+		Tree:       plumbing.ZeroHash.String(),
+		Commit:     plumbing.ZeroHash.String(),
+	}
+
+	data, err := k.encode()
+	require.NoError(err)
+
+	var k2 commitFileIndexKey
+	require.NoError(k2.decode(data))
+
+	require.Equal(k, k2)
 }

--- a/commit_trees.go
+++ b/commit_trees.go
@@ -1,6 +1,7 @@
 package gitbase
 
 import (
+	"bytes"
 	"io"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -104,7 +105,12 @@ func (*commitTreesTable) IndexKeyValueIter(
 		return nil, err
 	}
 
-	return &rowKeyValueIter{iter, colNames, CommitTreesSchema}, nil
+	return &rowKeyValueIter{
+		new(commitTreesRowKeyMapper),
+		iter,
+		colNames,
+		CommitTreesSchema,
+	}, nil
 }
 
 // WithProjectFiltersAndIndex implements sql.Indexable interface.
@@ -120,13 +126,70 @@ func (*commitTreesTable) WithProjectFiltersAndIndex(
 		return nil, ErrInvalidGitbaseSession.New(ctx.Session)
 	}
 
-	var iter sql.RowIter = &rowIndexIter{index}
+	var iter sql.RowIter = &rowIndexIter{new(commitTreesRowKeyMapper), index}
 
 	if len(filters) > 0 {
 		iter = plan.NewFilterIter(ctx, expression.JoinAnd(filters...), iter)
 	}
 
 	return sql.NewSpanIter(span, iter), nil
+}
+
+type commitTreesRowKeyMapper struct{}
+
+func (commitTreesRowKeyMapper) fromRow(row sql.Row) ([]byte, error) {
+	if len(row) != 3 {
+		return nil, errRowKeyMapperRowLength.New(3, len(row))
+	}
+
+	repo, ok := row[0].(string)
+	if !ok {
+		return nil, errRowKeyMapperColType.New(0, repo, row[0])
+	}
+
+	commit, ok := row[1].(string)
+	if !ok {
+		return nil, errRowKeyMapperColType.New(1, commit, row[1])
+	}
+
+	tree, ok := row[2].(string)
+	if !ok {
+		return nil, errRowKeyMapperColType.New(2, tree, row[2])
+	}
+
+	var buf bytes.Buffer
+	writeString(&buf, repo)
+
+	if err := writeHash(&buf, commit); err != nil {
+		return nil, err
+	}
+
+	if err := writeHash(&buf, tree); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (commitTreesRowKeyMapper) toRow(data []byte) (sql.Row, error) {
+	var buf = bytes.NewBuffer(data)
+
+	repo, err := readString(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	commit, err := readHash(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	tree, err := readHash(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return sql.Row{repo, commit, tree}, nil
 }
 
 func commitTreesIterBuilder(ctx *sql.Context, selectors selectors, columns []sql.Expression) (RowRepoIter, error) {

--- a/commits.go
+++ b/commits.go
@@ -360,7 +360,7 @@ func (i *commitsKeyValueIter) Next() ([]interface{}, []byte, error) {
 			hash = commit.Hash.String()
 		}
 
-		key, err := encodeIndexKey(packOffsetIndexKey{
+		key, err := encodeIndexKey(&packOffsetIndexKey{
 			Repository: i.repo.ID,
 			Packfile:   packfile.String(),
 			Offset:     offset,

--- a/commits_test.go
+++ b/commits_test.go
@@ -215,7 +215,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 
 	var expected = []keyValue{
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     682,
@@ -226,7 +226,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1292,
@@ -237,7 +237,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     186,
@@ -248,7 +248,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     353,
@@ -259,7 +259,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     905,
@@ -270,7 +270,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     516,
@@ -281,7 +281,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1459,
@@ -292,7 +292,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1130,
@@ -303,7 +303,7 @@ func TestCommitsIndexKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, packOffsetIndexKey{
+			assertEncodeKey(t, &packOffsetIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     12,

--- a/files_test.go
+++ b/files_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
@@ -167,7 +168,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 
 	var expected = []keyValue{
 		{
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -180,7 +181,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"32858aad3c383ed1ff0a0f9bdf231d54a00c9e88",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1752,
@@ -193,7 +194,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d3ff53e0564a9f87d8e84b6e28e5060e517008aa",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -206,7 +207,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c192bd6a24ea1ab01d78686e417c8bdc7c3d197f",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2418,
@@ -219,7 +220,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"7e59600739c96546163833214c36459e324bad0a",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2436,
@@ -232,7 +233,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d5c0f4ab811897cadf03aec358ae60d21f91c50d",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78932,
@@ -245,7 +246,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"880cd14280f4b9b6ed3986d6671f907d7cc2a198",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     79864,
@@ -258,7 +259,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"49c6bb89b17060d7b4deacb7b338fcc6ea2352a9",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     81707,
@@ -271,7 +272,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c8f1d8c61f9da76f4cb49fd86322b6e685dba956",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     82000,
@@ -284,7 +285,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"9a48f23120e880dfbe41f7c9b7b708e9ee62a492",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -297,7 +298,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"32858aad3c383ed1ff0a0f9bdf231d54a00c9e88",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1752,
@@ -310,7 +311,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d3ff53e0564a9f87d8e84b6e28e5060e517008aa",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -323,7 +324,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c192bd6a24ea1ab01d78686e417c8bdc7c3d197f",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2436,
@@ -336,7 +337,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d5c0f4ab811897cadf03aec358ae60d21f91c50d",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78932,
@@ -349,7 +350,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"880cd14280f4b9b6ed3986d6671f907d7cc2a198",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     79864,
@@ -362,7 +363,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"49c6bb89b17060d7b4deacb7b338fcc6ea2352a9",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     81707,
@@ -375,7 +376,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c8f1d8c61f9da76f4cb49fd86322b6e685dba956",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     82000,
@@ -388,7 +389,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"9a48f23120e880dfbe41f7c9b7b708e9ee62a492",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     85438,
@@ -401,7 +402,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"9dea2395f5403188298c1dabe8bdafe562c491e3",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -414,7 +415,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"32858aad3c383ed1ff0a0f9bdf231d54a00c9e88",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1752,
@@ -427,7 +428,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d3ff53e0564a9f87d8e84b6e28e5060e517008aa",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -440,7 +441,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c192bd6a24ea1ab01d78686e417c8bdc7c3d197f",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2436,
@@ -453,7 +454,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d5c0f4ab811897cadf03aec358ae60d21f91c50d",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78932,
@@ -466,7 +467,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"880cd14280f4b9b6ed3986d6671f907d7cc2a198",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     79864,
@@ -479,7 +480,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"49c6bb89b17060d7b4deacb7b338fcc6ea2352a9",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     81707,
@@ -492,7 +493,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c8f1d8c61f9da76f4cb49fd86322b6e685dba956",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     82000,
@@ -505,7 +506,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"9a48f23120e880dfbe41f7c9b7b708e9ee62a492",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -518,7 +519,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"32858aad3c383ed1ff0a0f9bdf231d54a00c9e88",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1752,
@@ -531,7 +532,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d3ff53e0564a9f87d8e84b6e28e5060e517008aa",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -544,7 +545,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c192bd6a24ea1ab01d78686e417c8bdc7c3d197f",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2436,
@@ -557,7 +558,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d5c0f4ab811897cadf03aec358ae60d21f91c50d",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     79864,
@@ -570,7 +571,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"49c6bb89b17060d7b4deacb7b338fcc6ea2352a9",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     81707,
@@ -583,7 +584,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c8f1d8c61f9da76f4cb49fd86322b6e685dba956",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -596,7 +597,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"32858aad3c383ed1ff0a0f9bdf231d54a00c9e88",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1752,
@@ -609,7 +610,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d3ff53e0564a9f87d8e84b6e28e5060e517008aa",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -622,7 +623,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c192bd6a24ea1ab01d78686e417c8bdc7c3d197f",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2436,
@@ -635,7 +636,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d5c0f4ab811897cadf03aec358ae60d21f91c50d",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -648,7 +649,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"32858aad3c383ed1ff0a0f9bdf231d54a00c9e88",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1752,
@@ -661,7 +662,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d3ff53e0564a9f87d8e84b6e28e5060e517008aa",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -674,7 +675,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c192bd6a24ea1ab01d78686e417c8bdc7c3d197f",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -687,7 +688,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"32858aad3c383ed1ff0a0f9bdf231d54a00c9e88",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -700,7 +701,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"c192bd6a24ea1ab01d78686e417c8bdc7c3d197f",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     2436,
@@ -713,7 +714,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"d5c0f4ab811897cadf03aec358ae60d21f91c50d",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1591,
@@ -726,7 +727,7 @@ func TestFilesIndexKeyValueIter(t *testing.T) {
 				"32858aad3c383ed1ff0a0f9bdf231d54a00c9e88",
 			},
 		}, {
-			assertEncodeKey(t, fileIndexKey{
+			assertEncodeKey(t, &fileIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     1780,
@@ -753,4 +754,44 @@ func TestFilesIndex(t *testing.T) {
 			expression.NewLiteral("LICENSE", sql.Text),
 		)},
 	)
+}
+
+func TestEncodeFileIndexKey(t *testing.T) {
+	require := require.New(t)
+
+	k := fileIndexKey{
+		Repository: "repo1",
+		Packfile:   plumbing.ZeroHash.String(),
+		Offset:     1234,
+		Hash:       "",
+		Name:       "foo/bar.md",
+		Mode:       5,
+		Tree:       plumbing.ZeroHash.String(),
+	}
+
+	data, err := k.encode()
+	require.NoError(err)
+
+	var k2 fileIndexKey
+	require.NoError(k2.decode(data))
+
+	require.Equal(k, k2)
+
+	k = fileIndexKey{
+		Repository: "repo1",
+		Packfile:   plumbing.ZeroHash.String(),
+		Offset:     -1,
+		Hash:       plumbing.ZeroHash.String(),
+		Name:       "foo/bar.md",
+		Mode:       5,
+		Tree:       plumbing.ZeroHash.String(),
+	}
+
+	data, err = k.encode()
+	require.NoError(err)
+
+	var k3 fileIndexKey
+	require.NoError(k3.decode(data))
+
+	require.Equal(k, k3)
 }

--- a/ref_commits_test.go
+++ b/ref_commits_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
@@ -148,12 +149,19 @@ func TestRefCommitsIndexKeyValueIter(t *testing.T) {
 	var expected []keyValue
 	for _, row := range rows {
 		var kv keyValue
-		kv.key = assertEncodeKey(t, row)
+		kv.key = assertEncodeRefCommitsRow(t, row)
 		kv.values = append(kv.values, row[2], row[1])
 		expected = append(expected, kv)
 	}
 
 	assertIndexKeyValueIter(t, iter, expected)
+}
+
+func assertEncodeRefCommitsRow(t *testing.T, row sql.Row) []byte {
+	t.Helper()
+	k, err := new(refCommitsRowKeyMapper).fromRow(row)
+	require.NoError(t, err)
+	return k
 }
 
 func TestRefCommitsIndex(t *testing.T) {
@@ -165,4 +173,18 @@ func TestRefCommitsIndex(t *testing.T) {
 			expression.NewLiteral("HEAD", sql.Text),
 		)},
 	)
+}
+
+func TestRefCommitsRowKeyMapper(t *testing.T) {
+	require := require.New(t)
+	row := sql.Row{"repo1", plumbing.ZeroHash.String(), "ref_name", int64(1)}
+	mapper := new(refCommitsRowKeyMapper)
+
+	k, err := mapper.fromRow(row)
+	require.NoError(err)
+
+	row2, err := mapper.toRow(k)
+	require.NoError(err)
+
+	require.Equal(row, row2)
 }

--- a/references.go
+++ b/references.go
@@ -1,6 +1,8 @@
 package gitbase
 
 import (
+	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -115,7 +117,12 @@ func (*referencesTable) IndexKeyValueIter(
 		return nil, err
 	}
 
-	return &rowKeyValueIter{iter, colNames, RefsSchema}, nil
+	return &rowKeyValueIter{
+		new(refRowKeyMapper),
+		iter,
+		colNames,
+		RefsSchema,
+	}, nil
 }
 
 // WithProjectFiltersAndIndex implements sql.Indexable interface.
@@ -131,13 +138,67 @@ func (*referencesTable) WithProjectFiltersAndIndex(
 		return nil, ErrInvalidGitbaseSession.New(ctx.Session)
 	}
 
-	var iter sql.RowIter = &rowIndexIter{index}
+	var iter sql.RowIter = &rowIndexIter{new(refRowKeyMapper), index}
 
 	if len(filters) > 0 {
 		iter = plan.NewFilterIter(ctx, expression.JoinAnd(filters...), iter)
 	}
 
 	return sql.NewSpanIter(span, iter), nil
+}
+
+type refRowKeyMapper struct{}
+
+func (refRowKeyMapper) fromRow(row sql.Row) ([]byte, error) {
+	if len(row) != 3 {
+		return nil, errRowKeyMapperRowLength.New(3, len(row))
+	}
+
+	repo, ok := row[0].(string)
+	if !ok {
+		return nil, errRowKeyMapperColType.New(0, repo, row[0])
+	}
+
+	name, ok := row[1].(string)
+	if !ok {
+		return nil, errRowKeyMapperColType.New(1, name, row[1])
+	}
+
+	commit, ok := row[2].(string)
+	if !ok {
+		return nil, errRowKeyMapperColType.New(2, commit, row[2])
+	}
+
+	var buf bytes.Buffer
+	writeString(&buf, repo)
+	writeString(&buf, name)
+
+	if err := writeHash(&buf, commit); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (refRowKeyMapper) toRow(data []byte) (sql.Row, error) {
+	var buf = bytes.NewBuffer(data)
+
+	repo, err := readString(buf)
+	if err != nil {
+		return nil, fmt.Errorf("can't read ref repository: %s", err)
+	}
+
+	name, err := readString(buf)
+	if err != nil {
+		return nil, fmt.Errorf("can't read ref name: %s", err)
+	}
+
+	commit, err := readHash(buf)
+	if err != nil {
+		return nil, fmt.Errorf("can't read ref hash: %s", err)
+	}
+
+	return sql.Row{repo, name, commit}, nil
 }
 
 func referencesIterBuilder(_ *sql.Context, selectors selectors, _ []sql.Expression) (RowRepoIter, error) {

--- a/remotes_test.go
+++ b/remotes_test.go
@@ -136,7 +136,7 @@ func TestRemotesIndexKeyValueIter(t *testing.T) {
 
 	var expected = []keyValue{
 		{
-			key:    assertEncodeKey(t, remoteIndexKey{path, 0, 0}),
+			key:    assertEncodeKey(t, &remoteIndexKey{path, 0, 0}),
 			values: []interface{}{"origin", "git@github.com:git-fixtures/basic.git"},
 		},
 	}
@@ -153,4 +153,21 @@ func TestRemotesIndex(t *testing.T) {
 			expression.NewLiteral("foo", sql.Text),
 		)},
 	)
+}
+
+func TestEncodeRemoteIndexKey(t *testing.T) {
+	require := require.New(t)
+
+	k := remoteIndexKey{
+		Repository: "repo1",
+		Pos:        5,
+		URLPos:     7,
+	}
+
+	data, err := k.encode()
+	require.NoError(err)
+
+	var k2 remoteIndexKey
+	require.NoError(k2.decode(data))
+	require.Equal(k, k2)
 }

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -121,11 +121,18 @@ func TestRepositoriesIndexKeyValueIter(t *testing.T) {
 	assertIndexKeyValueIter(t, iter,
 		[]keyValue{
 			{
-				assertEncodeKey(t, sql.NewRow(path)),
+				assertEncodeRepoRow(t, sql.NewRow(path)),
 				[]interface{}{path},
 			},
 		},
 	)
+}
+
+func assertEncodeRepoRow(t *testing.T, row sql.Row) []byte {
+	t.Helper()
+	k, err := new(repoRowKeyMapper).fromRow(row)
+	require.NoError(t, err)
+	return k
 }
 
 func TestRepositoriesIndex(t *testing.T) {

--- a/squash_iterator.go
+++ b/squash_iterator.go
@@ -1075,7 +1075,7 @@ func (i *squashRefCommitsIndexIter) New(ctx *sql.Context, pool *RepositoryPool) 
 	return &squashRefCommitsIndexIter{
 		ctx:           ctx,
 		index:         i.index,
-		iter:          &rowIndexIter{values},
+		iter:          &rowIndexIter{new(refCommitsRowKeyMapper), values},
 		filters:       i.filters,
 		pool:          pool,
 		skipGitErrors: session.SkipGitErrors,
@@ -1671,7 +1671,7 @@ func (i *squashCommitTreesIndexIter) New(ctx *sql.Context, pool *RepositoryPool)
 	return &squashCommitTreesIndexIter{
 		ctx:           ctx,
 		index:         i.index,
-		iter:          &rowIndexIter{values},
+		iter:          &rowIndexIter{new(commitTreesRowKeyMapper), values},
 		filters:       i.filters,
 		pool:          pool,
 		skipGitErrors: session.SkipGitErrors,
@@ -2512,7 +2512,7 @@ func (i *squashCommitBlobsIndexIter) New(ctx *sql.Context, pool *RepositoryPool)
 	return &squashCommitBlobsIndexIter{
 		ctx:           ctx,
 		index:         i.index,
-		iter:          &rowIndexIter{values},
+		iter:          &rowIndexIter{new(commitBlobsRowKeyMapper), values},
 		filters:       i.filters,
 		pool:          pool,
 		skipGitErrors: session.SkipGitErrors,

--- a/tree_entries.go
+++ b/tree_entries.go
@@ -1,6 +1,7 @@
 package gitbase
 
 import (
+	"bytes"
 	"io"
 	"strconv"
 
@@ -281,6 +282,60 @@ type treeEntriesIndexKey struct {
 	Hash       string
 }
 
+func (k *treeEntriesIndexKey) encode() ([]byte, error) {
+	var buf bytes.Buffer
+	writeString(&buf, k.Repository)
+	writeHash(&buf, k.Packfile)
+	writeBool(&buf, k.Offset >= 0)
+	if k.Offset >= 0 {
+		writeInt64(&buf, k.Offset)
+	} else {
+		if err := writeHash(&buf, k.Hash); err != nil {
+			return nil, err
+		}
+	}
+	writeInt64(&buf, int64(k.Pos))
+	return buf.Bytes(), nil
+}
+
+func (k *treeEntriesIndexKey) decode(data []byte) error {
+	var buf = bytes.NewBuffer(data)
+	var err error
+
+	if k.Repository, err = readString(buf); err != nil {
+		return err
+	}
+
+	if k.Packfile, err = readHash(buf); err != nil {
+		return err
+	}
+
+	ok, err := readBool(buf)
+	if err != nil {
+		return err
+	}
+
+	if ok {
+		k.Hash = ""
+		if k.Offset, err = readInt64(buf); err != nil {
+			return err
+		}
+	} else {
+		k.Offset = -1
+		if k.Hash, err = readHash(buf); err != nil {
+			return err
+		}
+	}
+
+	pos, err := readInt64(buf)
+	if err != nil {
+		return err
+	}
+
+	k.Pos = int(pos)
+	return nil
+}
+
 type treeEntriesKeyValueIter struct {
 	pool    *RepositoryPool
 	repos   *RepositoryIter
@@ -357,7 +412,7 @@ func (i *treeEntriesKeyValueIter) Next() ([]interface{}, []byte, error) {
 			hash = i.tree.Hash.String()
 		}
 
-		key, err := encodeIndexKey(treeEntriesIndexKey{
+		key, err := encodeIndexKey(&treeEntriesIndexKey{
 			Repository: i.repo.ID,
 			Packfile:   packfile.String(),
 			Offset:     offset,

--- a/tree_entries_test.go
+++ b/tree_entries_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
@@ -119,7 +120,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 
 	var expected = []keyValue{
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78685,
@@ -131,7 +132,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78685,
@@ -143,7 +144,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78685,
@@ -155,7 +156,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78685,
@@ -167,7 +168,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78685,
@@ -179,7 +180,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78264,
@@ -191,7 +192,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78184,
@@ -203,7 +204,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78184,
@@ -215,7 +216,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78833,
@@ -227,7 +228,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78833,
@@ -239,7 +240,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78833,
@@ -251,7 +252,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78135,
@@ -263,7 +264,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78358,
@@ -275,7 +276,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78358,
@@ -287,7 +288,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78358,
@@ -299,7 +300,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78358,
@@ -311,7 +312,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78358,
@@ -323,7 +324,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78358,
@@ -335,7 +336,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78358,
@@ -347,7 +348,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78358,
@@ -359,7 +360,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78852,
@@ -371,7 +372,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78852,
@@ -383,7 +384,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78720,
@@ -395,7 +396,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78720,
@@ -407,7 +408,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78720,
@@ -419,7 +420,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78313,
@@ -431,7 +432,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78636,
@@ -443,7 +444,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78636,
@@ -455,7 +456,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78636,
@@ -467,7 +468,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78636,
@@ -479,7 +480,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78636,
@@ -491,7 +492,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78636,
@@ -503,7 +504,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78636,
@@ -515,7 +516,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78636,
@@ -527,7 +528,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78704,
@@ -539,7 +540,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78704,
@@ -551,7 +552,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78704,
@@ -563,7 +564,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78704,
@@ -575,7 +576,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78619,
@@ -587,7 +588,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78619,
@@ -599,7 +600,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78619,
@@ -611,7 +612,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78619,
@@ -623,7 +624,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78619,
@@ -635,7 +636,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78619,
@@ -647,7 +648,7 @@ func TestTreeEntriesKeyValueIter(t *testing.T) {
 			},
 		},
 		{
-			assertEncodeKey(t, treeEntriesIndexKey{
+			assertEncodeKey(t, &treeEntriesIndexKey{
 				Repository: path,
 				Packfile:   "323a4b6b5de684f9966953a043bc800154e5dbfa",
 				Offset:     78619,
@@ -672,4 +673,40 @@ func TestTreeEntriesIndex(t *testing.T) {
 			expression.NewLiteral("LICENSE", sql.Text),
 		)},
 	)
+}
+
+func TestEncodeTreeEntriesIndexKey(t *testing.T) {
+	require := require.New(t)
+
+	k := treeEntriesIndexKey{
+		Repository: "repo1",
+		Packfile:   plumbing.ZeroHash.String(),
+		Offset:     1234,
+		Hash:       "",
+		Pos:        5,
+	}
+
+	data, err := k.encode()
+	require.NoError(err)
+
+	var k2 treeEntriesIndexKey
+	require.NoError(k2.decode(data))
+
+	require.Equal(k, k2)
+
+	k = treeEntriesIndexKey{
+		Repository: "repo1",
+		Packfile:   plumbing.ZeroHash.String(),
+		Offset:     -1,
+		Hash:       plumbing.ZeroHash.String(),
+		Pos:        5,
+	}
+
+	data, err = k.encode()
+	require.NoError(err)
+
+	var k3 treeEntriesIndexKey
+	require.NoError(k3.decode(data))
+
+	require.Equal(k, k3)
 }


### PR DESCRIPTION
By using custom encoder and decoder for the index keys, as opposed to golang `gob` we can save a lot of space.

This implements our own way of encoding and decoding those index keys by just writing bytes for each thing.

- For string values we write first the size (int64 in binary) and then the string itself.
- For hashes we just write 40 bytes.
- For int64 we write the number in binary.
- For bools we write 0 or 1.

Since some objects can be unpacked and not in the packfile, there are cases where the key has an offset of -1 and a hash instead or an offset >= 0 and empty hash.

Because now we're in control, instead of saving both the hash and the offset we store a bool and just one of them, potentially saving some space. Also, since this is not using reflection it should also be way faster than before.

By definition, this takes less space than before and this is true no matter which key you're encoding because gob stores more than just the value and we do not. But just to have some numbers I did an index on `files`, which is the most space consuming table, saving `file_path` and `blob_hash`.

I did it on a repository of 113MB with 197500 rows (src-d/datasets).
- Previous index size was 109.1MB
- Current index size was 75MB
In this case, we saved 31.25% of space, so I'd say it's ok.