### PR TITLE
gitbase: fix tree entry index iteration when object is unpacked

### DIFF
--- a/tree_entries.go
+++ b/tree_entries.go
@@ -414,7 +414,8 @@ func (i *treeEntriesIndexIter) Next() (sql.Row, error) {
 	i.repoID = key.Repository
 
 	var tree *object.Tree
-	if i.prevTreeOffset == key.Offset {
+	if i.prevTreeOffset == key.Offset && key.Offset >= 0 ||
+		(i.tree != nil && i.tree.Hash.String() == key.Hash) {
 		tree = i.tree
 	} else {
 		var obj object.Object


### PR DESCRIPTION
Closes #355 

After a lot of debugging, it turns out it was this little tiny stupid thing 😞 

I found another error while storing the index (not querying) of the tree_entries table, but I think that has something to do with go-git and not gitbase in particular.