### PR TITLE
gitbase/repository_pool: change repository to be an interface

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -369,7 +369,7 @@ func (i *blobsKeyValueIter) Next() ([]interface{}, []byte, error) {
 			}
 
 			repo := i.pool.repositories[i.repo.ID]
-			i.idx, err = newRepositoryIndex(repo.path, repo.kind)
+			i.idx, err = newRepositoryIndex(repo)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/commit_files.go
+++ b/commit_files.go
@@ -399,7 +399,7 @@ func (i *commitFilesKeyValueIter) Next() ([]interface{}, []byte, error) {
 			}
 
 			repo := i.pool.repositories[i.repo.ID]
-			i.idx, err = newRepositoryIndex(repo.path, repo.kind)
+			i.idx, err = newRepositoryIndex(repo)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/commits.go
+++ b/commits.go
@@ -334,7 +334,7 @@ func (i *commitsKeyValueIter) Next() ([]interface{}, []byte, error) {
 			}
 
 			r := i.pool.repositories[i.repo.ID]
-			i.idx, err = newRepositoryIndex(r.path, r.kind)
+			i.idx, err = newRepositoryIndex(r)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/files.go
+++ b/files.go
@@ -412,7 +412,7 @@ func (i *filesKeyValueIter) Next() ([]interface{}, []byte, error) {
 			}
 
 			repo := i.pool.repositories[i.repo.ID]
-			i.idx, err = newRepositoryIndex(repo.path, repo.kind)
+			i.idx, err = newRepositoryIndex(repo)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/fs_error_test.go
+++ b/fs_error_test.go
@@ -91,37 +91,13 @@ func brokenFS(
 	}
 
 	var brokenFS billy.Filesystem
-	if brokenType == 0 {
+	if brokenType == brokenNone {
 		brokenFS = dotFS
 	} else {
 		brokenFS = NewBrokenFS(brokenType, dotFS)
 	}
 
 	return brokenFS, nil
-}
-
-func brokenRepo(
-	brokenType brokenType,
-	fs billy.Filesystem,
-) (*git.Repository, error) {
-	dotFS, err := fs.Chroot(".git")
-	if err != nil {
-		return nil, err
-	}
-
-	var brokenFS billy.Filesystem
-	if brokenType == 0 {
-		brokenFS = dotFS
-	} else {
-		brokenFS = NewBrokenFS(brokenType, dotFS)
-	}
-
-	storage, err := filesystem.NewStorage(brokenFS)
-	if err != nil {
-		return nil, err
-	}
-
-	return git.Open(storage, fs)
 }
 
 func testTable(t *testing.T, tableName string, number int) {
@@ -179,6 +155,8 @@ func (r *billyRepository) Path() string {
 type brokenType uint64
 
 const (
+	// no errors
+	brokenNone brokenType = 0
 	// packfile has read errors
 	brokenPackfile brokenType = 1 << iota
 	// there's no index for one packfile

--- a/packfiles_test.go
+++ b/packfiles_test.go
@@ -13,7 +13,7 @@ var testSivaFilePath = filepath.Join("_testdata", "fff7062de8474d10a67d417ccea87
 func TestRepositoryPackfiles(t *testing.T) {
 	require := require.New(t)
 
-	fs, packfiles, err := repositoryPackfiles(testSivaFilePath, sivaRepo)
+	fs, packfiles, err := repositoryPackfiles(sivaRepo("siva", testSivaFilePath))
 
 	require.NoError(err)
 	require.Equal([]plumbing.Hash{
@@ -24,7 +24,7 @@ func TestRepositoryPackfiles(t *testing.T) {
 }
 
 func TestRepositoryIndex(t *testing.T) {
-	idx, err := newRepositoryIndex(testSivaFilePath, sivaRepo)
+	idx, err := newRepositoryIndex(sivaRepo("siva", testSivaFilePath))
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -39,7 +39,7 @@ func TestRepositoriesTable_RowIter(t *testing.T) {
 	pool := NewRepositoryPool()
 
 	for _, id := range repoIDs {
-		pool.Add(id, "", gitRepo)
+		pool.Add(gitRepo(id, ""))
 	}
 
 	session := NewSession(pool)

--- a/repository_pool.go
+++ b/repository_pool.go
@@ -146,41 +146,6 @@ func (r *sivaRepository) Path() string {
 	return r.path
 }
 
-type billyRepository struct {
-	id string
-	fs billy.Filesystem
-}
-
-func billyRepo(id string, fs billy.Filesystem) repository {
-	return &billyRepository{id, fs}
-}
-
-func (r *billyRepository) ID() string {
-	return r.id
-}
-
-func (r *billyRepository) Repo() (*Repository, error) {
-	storage, err := filesystem.NewStorage(r.fs)
-	if err != nil {
-		return nil, err
-	}
-
-	repo, err := git.Open(storage, r.fs)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewRepository(r.id, repo), nil
-}
-
-func (r *billyRepository) FS() (billy.Filesystem, error) {
-	return r.fs, nil
-}
-
-func (r *billyRepository) Path() string {
-	return r.id
-}
-
 // RepositoryPool holds a pool git repository paths and
 // functionality to open and iterate them.
 type RepositoryPool struct {
@@ -302,11 +267,6 @@ func (p *RepositoryPool) addSivaFile(root, path string, f os.FileInfo) {
 	} else {
 		logrus.WithField("file", relativeFileName).Warn("found a non-siva file, skipping")
 	}
-}
-
-// AddBilly inserts a billy filesystem containing a git repo to the pool.
-func (p *RepositoryPool) AddBilly(id string, fs billy.Filesystem) error {
-	return p.Add(billyRepo(id, fs))
 }
 
 // GetPos retrieves a repository at a given position. If the position is

--- a/repository_pool.go
+++ b/repository_pool.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/go-billy-siva.v4"
+	billy "gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/osfs"
 	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-git.v4"
@@ -79,19 +80,106 @@ func NewSivaRepositoryFromPath(id, path string) (*Repository, error) {
 	return NewRepository(id, repo), nil
 }
 
-type repository struct {
-	kind repoKind
-	path string
-	repo *git.Repository
+type repository interface {
+	ID() string
+	Repo() (*Repository, error)
+	FS() (billy.Filesystem, error)
+	Path() string
 }
 
-type repoKind byte
+type gitRepository struct {
+	id   string
+	path string
+}
 
-const (
-	gitRepo repoKind = iota
-	sivaRepo
-	initializedrepo
-)
+func gitRepo(id, path string) repository {
+	return &gitRepository{id, path}
+}
+
+func (r *gitRepository) ID() string {
+	return r.id
+}
+
+func (r *gitRepository) Repo() (*Repository, error) {
+	return NewRepositoryFromPath(r.id, r.path)
+}
+
+func (r *gitRepository) FS() (billy.Filesystem, error) {
+	return osfs.New(r.path), nil
+}
+
+func (r *gitRepository) Path() string {
+	return r.path
+}
+
+type sivaRepository struct {
+	id   string
+	path string
+}
+
+func sivaRepo(id, path string) repository {
+	return &sivaRepository{id, path}
+}
+
+func (r *sivaRepository) ID() string {
+	return r.id
+}
+
+func (r *sivaRepository) Repo() (*Repository, error) {
+	return NewSivaRepositoryFromPath(r.id, r.path)
+}
+
+func (r *sivaRepository) FS() (billy.Filesystem, error) {
+	localfs := osfs.New(filepath.Dir(r.path))
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "gitbase-siva")
+	if err != nil {
+		return nil, err
+	}
+
+	tmpfs := osfs.New(tmpDir)
+
+	return sivafs.NewFilesystem(localfs, filepath.Base(r.path), tmpfs)
+}
+
+func (r *sivaRepository) Path() string {
+	return r.path
+}
+
+type billyRepository struct {
+	id string
+	fs billy.Filesystem
+}
+
+func billyRepo(id string, fs billy.Filesystem) repository {
+	return &billyRepository{id, fs}
+}
+
+func (r *billyRepository) ID() string {
+	return r.id
+}
+
+func (r *billyRepository) Repo() (*Repository, error) {
+	storage, err := filesystem.NewStorage(r.fs)
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := git.Open(storage, r.fs)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewRepository(r.id, repo), nil
+}
+
+func (r *billyRepository) FS() (billy.Filesystem, error) {
+	return r.fs, nil
+}
+
+func (r *billyRepository) Path() string {
+	return r.id
+}
 
 // RepositoryPool holds a pool git repository paths and
 // functionality to open and iterate them.
@@ -108,13 +196,10 @@ func NewRepositoryPool() *RepositoryPool {
 }
 
 // Add inserts a new repository in the pool.
-func (p *RepositoryPool) Add(id, path string, kind repoKind) error {
-	return p.add(id, repository{kind, path, nil})
-}
-
-func (p *RepositoryPool) add(id string, repo repository) error {
+func (p *RepositoryPool) Add(repo repository) error {
+	id := repo.ID()
 	if r, ok := p.repositories[id]; ok {
-		return errRepoAlreadyRegistered.New(r.path)
+		return errRepoAlreadyRegistered.New(r.Path())
 	}
 
 	p.idOrder = append(p.idOrder, id)
@@ -137,7 +222,7 @@ func (p *RepositoryPool) AddGitWithID(id, path string) (string, error) {
 		return "", errRepoCannotOpen.Wrap(err, path)
 	}
 
-	err = p.Add(id, path, gitRepo)
+	err = p.Add(gitRepo(id, path))
 	if err != nil {
 		return "", err
 	}
@@ -212,16 +297,16 @@ func (p *RepositoryPool) addSivaFile(root, path string, f os.FileInfo) {
 
 	if strings.HasSuffix(f.Name(), ".siva") {
 		path := filepath.Join(path, f.Name())
-		p.Add(path, path, sivaRepo)
+		p.Add(sivaRepo(path, path))
 		logrus.WithField("file", relativeFileName).Debug("repository added")
 	} else {
 		logrus.WithField("file", relativeFileName).Warn("found a non-siva file, skipping")
 	}
 }
 
-// AddInitialized inserts an already initialized repository to the pool.
-func (p *RepositoryPool) AddInitialized(id string, repo *git.Repository) error {
-	return p.add(id, repository{initializedrepo, "", repo})
+// AddBilly inserts a billy filesystem containing a git repo to the pool.
+func (p *RepositoryPool) AddBilly(id string, fs billy.Filesystem) error {
+	return p.Add(billyRepo(id, fs))
 }
 
 // GetPos retrieves a repository at a given position. If the position is
@@ -249,24 +334,7 @@ func (p *RepositoryPool) GetRepo(id string) (*Repository, error) {
 		return nil, ErrPoolRepoNotFound.New(id)
 	}
 
-	var repo *Repository
-	var err error
-	switch r.kind {
-	case gitRepo:
-		repo, err = NewRepositoryFromPath(id, r.path)
-	case sivaRepo:
-		repo, err = NewSivaRepositoryFromPath(id, r.path)
-	case initializedrepo:
-		repo = NewRepository(id, r.repo)
-	default:
-		err = errInvalidRepoKind.New(r.kind)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return repo, nil
+	return r.Repo()
 }
 
 // RepoIter creates a new Repository iterator

--- a/repository_pool_test.go
+++ b/repository_pool_test.go
@@ -47,7 +47,7 @@ func TestRepositoryPoolBasic(t *testing.T) {
 	require.Nil(repo)
 	require.EqualError(err, ErrPoolRepoNotFound.New("foo").Error())
 
-	pool.Add("0", "/directory/should/not/exist", gitRepo)
+	pool.Add(gitRepo("0", "/directory/should/not/exist"))
 	repo, err = pool.GetPos(0)
 	require.Nil(repo)
 	require.EqualError(err, git.ErrRepositoryNotExists.Error())
@@ -57,7 +57,7 @@ func TestRepositoryPoolBasic(t *testing.T) {
 
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 
-	err = pool.Add("1", path, gitRepo)
+	err = pool.Add(gitRepo("1", path))
 	require.NoError(err)
 
 	repo, err = pool.GetPos(1)
@@ -70,7 +70,7 @@ func TestRepositoryPoolBasic(t *testing.T) {
 	require.Equal("1", repo.ID)
 	require.NotNil(repo.Repo)
 
-	err = pool.Add("1", path, gitRepo)
+	err = pool.Add(gitRepo("1", path))
 	require.Error(err)
 	require.True(errRepoAlreadyRegistered.Is(err))
 
@@ -126,8 +126,8 @@ func TestRepositoryPoolIterator(t *testing.T) {
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 
 	pool := NewRepositoryPool()
-	pool.Add("0", path, gitRepo)
-	pool.Add("1", path, gitRepo)
+	pool.Add(gitRepo("0", path))
+	pool.Add(gitRepo("1", path))
 
 	iter, err := pool.RepoIter()
 	require.NoError(err)
@@ -217,7 +217,7 @@ func TestRepositoryRowIterator(t *testing.T) {
 	max := 64
 
 	for i := 0; i < max; i++ {
-		pool.Add(strconv.Itoa(i), path, gitRepo)
+		pool.Add(gitRepo(strconv.Itoa(i), path))
 	}
 
 	testRepoIter(max, require, ctx)
@@ -392,7 +392,7 @@ func testCaseRepositoryErrorIter(
 func TestRepositoryErrorIter(t *testing.T) {
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 	pool := NewRepositoryPool()
-	pool.Add("one", path, gitRepo)
+	pool.Add(gitRepo("one", path))
 
 	iter := &testErrorIter{}
 	testCaseRepositoryErrorIter(t, pool, iter, errIter, false)
@@ -400,7 +400,7 @@ func TestRepositoryErrorIter(t *testing.T) {
 
 func TestRepositoryErrorBadRepository(t *testing.T) {
 	pool := NewRepositoryPool()
-	pool.Add("one", "badpath", gitRepo)
+	pool.Add(gitRepo("one", "badpath"))
 
 	iter := &testErrorIter{}
 
@@ -429,7 +429,7 @@ func TestRepositoryErrorBadRepository(t *testing.T) {
 func TestRepositoryErrorBadRow(t *testing.T) {
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 	pool := NewRepositoryPool()
-	pool.Add("one", path, gitRepo)
+	pool.Add(gitRepo("one", path))
 
 	iter := &testErrorIter{}
 
@@ -464,7 +464,7 @@ func TestRepositoryErrorBadRow(t *testing.T) {
 func TestRepositoryIteratorOrder(t *testing.T) {
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 	pool := NewRepositoryPool()
-	pool.Add("one", path, gitRepo)
+	pool.Add(gitRepo("one", path))
 
 	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	ctx := sql.NewContext(timeout,

--- a/squash_iterator_test.go
+++ b/squash_iterator_test.go
@@ -692,7 +692,7 @@ func setupIterWithErrors(t *testing.T, badRepo bool, skipErrors bool) (*sql.Cont
 	pool := NewRepositoryPool()
 	if badRepo {
 		// TODO: add repo with errors
-		pool.Add("bad_repo", "bad_path", gitRepo)
+		pool.Add(gitRepo("bad_repo", "bad_path"))
 	}
 
 	for _, f := range fixtures.ByTag("worktree") {

--- a/tree_entries.go
+++ b/tree_entries.go
@@ -375,7 +375,7 @@ func (i *treeEntriesKeyValueIter) Next() ([]interface{}, []byte, error) {
 			}
 
 			repo := i.pool.repositories[i.repo.ID]
-			i.idx, err = newRepositoryIndex(repo.path, repo.kind)
+			i.idx, err = newRepositoryIndex(repo)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
Also add `billyRepo` for billy filesystems.

I'm not totally happy with the naming of `repository` interface as there's already a `Repository` structure and all the `gitRepository`/`gitRepo` for struct and constructor. Suggestions welcome.

