### PR TITLE
Fix gitbase version command

### DIFF
--- a/cmd/gitbase/main.go
+++ b/cmd/gitbase/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
+var (
 	name    = "gitbase"
 	version = "undefined"
 	build   = "undefined"


### PR DESCRIPTION
Related to https://github.com/src-d/gitbase/issues/387

On the latest master of Githbase f12563a96d2b80eb46c476222dd77a704ed6cd10

```
$ make packages
$ ./build/gitbase_darwin_amd64/gitbase version

gitbase (undefined) - build undefined
```

This PR fixes a typo in a previous work #389, where [`const`](https://github.com/src-d/gitbase/pull/389/commits/ecde5d738537dedc0d31ecf1df39d456abf0c5b4#diff-540338d1dca7c27f738d3dd59357ca7eR12) need to be a `var`, according to the [documentation](https://golang.org/cmd/link/).

Not sure if it's worth adding a test to CI to check for this.