### PR TITLE
cmd/gitbase: remove -h flag as shortcut for --host

### DIFF
--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -36,7 +36,7 @@ type Server struct {
 	Verbose       bool     `short:"v" description:"Activates the verbose mode"`
 	Git           []string `short:"g" long:"git" description:"Path where the git repositories are located, multiple directories can be defined. Accepts globs."`
 	Siva          []string `long:"siva" description:"Path where the siva repositories are located, multiple directories can be defined. Accepts globs."`
-	Host          string   `short:"h" long:"host" default:"localhost" description:"Host where the server is going to listen"`
+	Host          string   `long:"host" default:"localhost" description:"Host where the server is going to listen"`
 	Port          int      `short:"p" long:"port" default:"3306" description:"Port where the server is going to listen"`
 	User          string   `short:"u" long:"user" default:"root" description:"User name used for connection"`
 	Password      string   `short:"P" long:"password" default:"" description:"Password used for connection"`

--- a/docs/using-gitbase/configuration.md
+++ b/docs/using-gitbase/configuration.md
@@ -70,7 +70,7 @@ Help Options:
                        be defined. Accepts globs.
           --siva=      Path where the siva repositories are located, multiple directories can
                        be defined. Accepts globs.
-      -h, --host=      Host where the server is going to listen (default: localhost)
+          --host=      Host where the server is going to listen (default: localhost)
       -p, --port=      Port where the server is going to listen (default: 3306)
       -u, --user=      User name used for connection (default: root)
       -P, --password=  Password used for connection


### PR DESCRIPTION
Fixes #392 

It overlaps with help, which has higher priority, so it's effectively unusable.