### PR TITLE
internal/function: recover from panics in uast functions

### DIFF
--- a/internal/function/uast.go
+++ b/internal/function/uast.go
@@ -115,7 +115,13 @@ func (f UAST) String() string {
 }
 
 // Eval implements the Expression interface.
-func (f UAST) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+func (f UAST) Eval(ctx *sql.Context, row sql.Row) (out interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("uast: unknown error: %s", r)
+		}
+	}()
+
 	span, ctx := ctx.Span("gitbase.UAST")
 	defer span.Finish()
 
@@ -246,7 +252,13 @@ func (UASTXPath) Type() sql.Type {
 }
 
 // Eval implements the Expression interface.
-func (f *UASTXPath) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+func (f *UASTXPath) Eval(ctx *sql.Context, row sql.Row) (out interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("uastxpath: unknown error: %s", r)
+		}
+	}()
+
 	span, ctx := ctx.Span("gitbase.UASTXPath")
 	defer span.Finish()
 


### PR DESCRIPTION
Partial fix for #403 

I've opened an issue in bblfsh client-go about the panic, so when it's fixed there the permanent fix will be on gitbase after an upgrade.

For now, I think we should guard the uast functions with recovers just in case, since bblfsh seems to be the most common source of panics and returning an error instead.