### PR TITLE
Compare repos by ID.

### DIFF
--- a/packfiles.go
+++ b/packfiles.go
@@ -230,7 +230,7 @@ func newRepoObjectDecoder(
 	}
 
 	return &repoObjectDecoder{
-		repo:     repo.Path(),
+		repo:     repo.ID(),
 		packfile: hash,
 		decoder:  decoder,
 		storage:  storage,


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

The change forces decoder to compare repos by `ID` (not by `Path`). Thanks to this change `objectDecoder.decode` method doesn't have to create a new `RepoObjectDecoder` every time, but it re-uses internal cache.

It makes _full-scan_ queries for indexed columns much faster. For instance for 620 rows duration dropped from 14 sec. to 86 ms.

Closes: https://github.com/src-d/go-mysql-server/issues/324