### PR TITLE
Add -g option for backward compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ _cgo_export.*
 
 _testmain.go
 
-gitbase
 main
 *.exe
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _cgo_export.*
 
 _testmain.go
 
+gitbase
 main
 *.exe
 *.test

--- a/cmd/gitbase/main.go
+++ b/cmd/gitbase/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/src-d/gitbase/cmd/gitbase/command"
@@ -17,6 +18,16 @@ var (
 
 func main() {
 	parser := flags.NewNamedParser(name, flags.Default)
+	parser.UnknownOptionHandler = func(option string, arg flags.SplitArgument, args []string) ([]string, error) {
+		if "g" != option {
+			return nil, fmt.Errorf("unknown flag `%s'", option)
+		}
+		if len(args) == 0 {
+			return nil, fmt.Errorf("unknown flag `%s'", option)
+		}
+
+		return append(append(args, "-d"), args[0]), nil
+	}
 
 	_, err := parser.AddCommand("server", command.ServerDescription, command.ServerHelp,
 		&command.Server{


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

We can handle `-g` option for backward compatibility with previous versions.
`-g` is not documented, but we can use it as a alias for `-d` option, e.g.:
`./gitbase server -g /tmp/boo -d /tmp/repos/ -i /tmp/indexes`.

It's done to let run regression tests with `regression-gitbase` (which by default uses `-g`)