### PR TITLE
internal/function: add uast_extract udf

### DIFF
--- a/docs/using-gitbase/functions.md
+++ b/docs/using-gitbase/functions.md
@@ -12,6 +12,7 @@ To make some common tasks easier for the user, there are some functions to inter
 |uast(blob, [lang, [xpath]])json_blob| returns an array of UAST nodes as blobs in semantic mode                                                 |
 |uast_mode(mode, blob, lang)json_blob| returns an array of UAST nodes as blobs specifying its language and mode (semantic, annotated or native) |
 |uast_xpath(json_blob, xpath)| performs an XPath query over the given UAST nodes                                                                |
+|uast_extract(json_blob, key)| extracts information identified by the given key from the uast nodes                                              |
 
 ## Standard functions
 

--- a/internal/function/registry.go
+++ b/internal/function/registry.go
@@ -4,10 +4,11 @@ import "gopkg.in/src-d/go-mysql-server.v0/sql"
 
 // Functions for gitbase queries.
 var Functions = sql.Functions{
-	"is_tag":     sql.Function1(NewIsTag),
-	"is_remote":  sql.Function1(NewIsRemote),
-	"language":   sql.FunctionN(NewLanguage),
-	"uast":       sql.FunctionN(NewUAST),
-	"uast_mode":  sql.Function3(NewUASTMode),
-	"uast_xpath": sql.Function2(NewUASTXPath),
+	"is_tag":       sql.Function1(NewIsTag),
+	"is_remote":    sql.Function1(NewIsRemote),
+	"language":     sql.FunctionN(NewLanguage),
+	"uast":         sql.FunctionN(NewUAST),
+	"uast_mode":    sql.Function3(NewUASTMode),
+	"uast_xpath":   sql.Function2(NewUASTXPath),
+	"uast_extract": sql.Function2(NewUASTExtract),
 }


### PR DESCRIPTION
This new UDF will be used to extract information from the uast nodes. The idea is pass a key identifying the information you want retrieve from a list of uast nodes and you will get back a list of values for each node in the list. For example:
```
MySQL [(none)]> select file_path,language(file_path) as lang, uast_extract(uast_xpath(uast_mode('annotated', blob_content, language(file_path)), '//*[@roleValue]'), "@type") as value_type from files where lang='Go' limit 1;
+-------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| file_path         | lang | value_type                                                                                                                                                                                                                                                                                                                                  |
+-------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| benchmark_test.go | Go   | [["Ident"],["Ident"],["Ident"],["Ident"],["BasicLit"],["Ident"],["BasicLit"],["Ident"],["BasicLit"],["Ident"],["BasicLit"],["Ident"],["BasicLit"],["Ident"],["Ident"],["Ident"],["Ident"],["Ident"],["BasicLit"],["Ident"],["BasicLit"],["Ident"],["BasicLit"],["Ident"],["BasicLit"],["Ident"],["BasicLit"],["Ident"],["Ident"],["Ident"]] |
+-------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.17 sec)

MySQL [(none)]> select file_path,language(file_path) as lang, uast_extract(uast_xpath(uast_mode('annotated', blob_content, language(file_path)), '//FuncLit'), "@role") as function_roles from files where lang='Go' limit 1;
+-------------------+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| file_path         | lang | function_roles                                                                                                                                                                                                                                                                                                                                                                       |
+-------------------+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| benchmark_test.go | Go   | [["Unannotated","Expression","Argument","Positional"],["Unannotated","Expression","Argument","Positional"],["Unannotated","Expression","Argument","Positional"],["Unannotated","Expression","Argument","Positional"],["Unannotated","Expression","Argument","Positional"],["Unannotated","Expression","Argument","Positional"],["Unannotated","Expression","Argument","Positional"]] |
+-------------------+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.14 sec)

MySQL [(none)]> select file_path,language(file_path) as lang, uast_extract(uast_xpath(uast_mode('annotated', blob_content, language(file_path)), '//*[@roleFunction]'), "internalRole") as internal_role from files where lang='Go' limit 1;
+-------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| file_path         | lang | internal_role                                                                                                                                                                                                                                                                                                                                                                                                 |
+-------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| benchmark_test.go | Go   | [["Decls"],["Type"],["Name"],["Body"],["Decls"],["Type"],["Name"],["Body"],["Decls"],["Type"],["Name"],["Body"],["Type"],["Decls"],["Type"],["Name"],["Body"],["Type"],["Decls"],["Type"],["Name"],["Body"],["Type"],["Decls"],["Type"],["Name"],["Body"],["Type"],["Decls"],["Type"],["Name"],["Body"],["Type"],["Decls"],["Type"],["Name"],["Body"],["Type"],["Decls"],["Type"],["Name"],["Body"],["Type"]] |
+-------------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.14 sec)
``` 

The [bblfsh/client-go](https://github.com/bblfsh/client-go) v2 is used although the uast version used is still v1. I think the signature of the udf will be the same for uast version 2, and for the special node's fields I'm using the keys `@type`, `@role`, `@token`, `@startpos`and `@endpos` but for [uast version 2 should change](https://github.com/bblfsh/sdk/blob/v2.1.0/uast/uast.go#L48).

It's just a first approach, WDYT @src-d/data-retrieval ?