### PR TITLE
internal/function: add LRU cache for uast and uast_mode functions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,55 +2,42 @@
 
 
 [[projects]]
-  digest = "1:289dd4d7abfb3ad2b5f728fbe9b1d5c1bf7d265a3eb9ef92869af1f7baba4c7a"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
-  pruneopts = ""
   revision = "b26d9c308763d68093482582cea63d69be07a0f0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c73b488e8b742d5d762279c1dc3abba715357ed3a30849025e5d81e30c41b0bd"
   name = "github.com/alcortesm/tgz"
   packages = ["."]
-  pruneopts = ""
   revision = "9c5fe88206d7765837fed3732a42ef88fc51f1a1"
 
 [[projects]]
-  digest = "1:ed112122ed4a920d944cc99b9d00b0441c11685939c28462c719488d36fe29aa"
   name = "github.com/boltdb/bolt"
   packages = ["."]
-  pruneopts = ""
   revision = "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8"
   version = "v1.3.1"
 
 [[projects]]
-  digest = "1:1660bb2e30cca08494f29b5593e387c6090fbe8936970ba947185b0ca000aec0"
   name = "github.com/cespare/xxhash"
   packages = ["."]
-  pruneopts = ""
   revision = "5c37fe3735342a2e0d01c87a907579987c8936cc"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:c46fd324e7902268373e1b337436a6377c196e2dbd7b35624c6256d29d494e78"
   name = "github.com/codahale/hdrhistogram"
   packages = ["."]
-  pruneopts = ""
   revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
 
 [[projects]]
-  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:ba7c75e38d81b9cf3e8601c081567be3b71bccca8c11aee5de98871360aa4d7b"
   name = "github.com/emirpasic/gods"
   packages = [
     "containers",
@@ -58,250 +45,198 @@
     "lists/arraylist",
     "trees",
     "trees/binaryheap",
-    "utils",
+    "utils"
   ]
-  pruneopts = ""
   revision = "f6c17b524822278a87e3b3bd809fec33b51f5b46"
   version = "v1.9.0"
 
 [[projects]]
-  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
     "proto",
     "protoc-gen-gogo/descriptor",
     "sortkeys",
-    "types",
+    "types"
   ]
-  pruneopts = ""
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = ""
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = ""
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:95abc4eba158a39873bd4fabdee576d0ae13826b550f8b710881d80ae4093a0f"
   name = "github.com/jbenet/go-context"
   packages = ["io"]
-  pruneopts = ""
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
 
 [[projects]]
-  digest = "1:ca5c90960520407749b98c49650f54f5f90a667796e85c5ee1597478f702fb91"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
-  pruneopts = ""
   revision = "c6ca198ec95c841fdb89fc0de7496fed11ab854e"
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:7fe04787f53bb61c1ba9c659b1a90ee3da16b4d6a1c41566bcb5077efbd30f97"
   name = "github.com/kevinburke/ssh_config"
   packages = ["."]
-  pruneopts = ""
   revision = "9fc7bb800b555d63157c65a904c86a2cc7b4e795"
   version = "0.4"
 
 [[projects]]
-  digest = "1:3108ec0946181c60040ff51b811908f89d03e521e2b4ade5ef5c65b3c0e911ae"
   name = "github.com/kr/pretty"
   packages = ["."]
-  pruneopts = ""
   revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:11b056b4421396ab14e384ab8ab8c2079b03f1e51aa5eb4d9b81f9e0d1aa8fbf"
   name = "github.com/kr/text"
   packages = ["."]
-  pruneopts = ""
   revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:bdcff37cd5cb47aa3a8a30771accadfcafa2d85adf919a3a1a1acb9e60ec2030"
   name = "github.com/mcuadros/go-lookup"
   packages = ["."]
-  pruneopts = ""
   revision = "5650f26be7675b629fff8356a50d906fa03e9c8b"
 
 [[projects]]
   branch = "master"
-  digest = "1:83854f6b1d2ce047b69657e3a87ba7602f4c5505e8bdfd02ab857db8e983bde1"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = ""
   revision = "58046073cbffe2f25d425fe1331102f55cf719de"
 
 [[projects]]
   branch = "master"
-  digest = "1:0de0f377aeccd41384e883c59c6f184c9db01c96db33a2724a1eaadd60f92629"
   name = "github.com/mitchellh/hashstructure"
   packages = ["."]
-  pruneopts = ""
   revision = "2bca23e0e452137f789efbc8610126fd8b94f73b"
 
 [[projects]]
   branch = "go1"
-  digest = "1:b8b842b1c221e57f599be4e31421eb804da1bf81538e2e9b8c3073938ad8e690"
   name = "github.com/moovweb/rubex"
   packages = ["."]
-  pruneopts = ""
   revision = "b3d9ff6ad7d9b14f94a91c8271cd9ad9e77132e5"
 
 [[projects]]
-  digest = "1:78fb99d6011c2ae6c72f3293a83951311147b12b06a5ffa43abf750c4fab6ac5"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
     "ext",
-    "log",
+    "log"
   ]
-  pruneopts = ""
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:049b5bee78dfdc9628ee0e557219c41f683e5b06c5a5f20eaba0105ccc586689"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
-  pruneopts = ""
   revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:8c515d4fe1dfe61082e9043f60b1dd19797bfeb77c04e9e96e968a13290df8d1"
   name = "github.com/pilosa/go-pilosa"
   packages = [
     ".",
-    "gopilosa_pbuf",
+    "gopilosa_pbuf"
   ]
-  pruneopts = ""
   revision = "2a176035ff61f2aa4bac197314e0f4464bfea4a4"
   version = "v0.9.0"
 
 [[projects]]
-  digest = "1:58fca81afb30787f9d052a730c931fbdf734501ba570d766bca2275893216311"
   name = "github.com/pilosa/pilosa"
   packages = [
     ".",
     "internal",
     "lru",
     "pql",
-    "roaring",
+    "roaring"
   ]
-  pruneopts = ""
   revision = "5f0ef7efca2285c1a0c6e9ef2c6bce94f38ec1ea"
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  pruneopts = ""
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:3962f553b77bf6c03fc07cd687a22dd3b00fe11aa14d31194f5505f5bb65cdc8"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
-  pruneopts = ""
   revision = "1744e2970ca51c86172c8190fadad617561ed6e7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = ""
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
   version = "v1.0.6"
 
 [[projects]]
-  digest = "1:d0b38ba6da419a6d4380700218eeec8623841d44a856bb57369c172fbf692ab4"
   name = "github.com/spf13/cast"
   packages = ["."]
-  pruneopts = ""
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:b1861b9a1aa0801b0b62945ed7477c1ab61a4bd03b55dfbc27f6d4f378110c8c"
   name = "github.com/src-d/gcfg"
   packages = [
     ".",
     "scanner",
     "token",
-    "types",
+    "types"
   ]
-  pruneopts = ""
   revision = "f187355171c936ac84a82793659ebb4936bc1c23"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require",
+    "require"
   ]
-  pruneopts = ""
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:5c64ec8b51a66a54a986a445dca34e97ce24eb6c859013b6f96806bd2ef06d2a"
   name = "github.com/toqueteos/trie"
   packages = ["."]
-  pruneopts = ""
   revision = "56fed4a05683322f125e2d78ee269bb102280392"
 
 [[projects]]
-  digest = "1:acdc8a34ebf61772eed1f00cad6667f37b8f2618bf958eb59d3e28c690703ad8"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -319,31 +254,25 @@
     "thrift-gen/jaeger",
     "thrift-gen/sampling",
     "thrift-gen/zipkincore",
-    "utils",
+    "utils"
   ]
-  pruneopts = ""
   revision = "b043381d944715b469fd6b37addfd30145ca1758"
   version = "v2.14.0"
 
 [[projects]]
-  digest = "1:aa1598d34009b45ce74fdabdd25e4258d7923d1e1b418d4c98482e79607cb9b0"
   name = "github.com/uber/jaeger-lib"
   packages = ["metrics"]
-  pruneopts = ""
   revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:afc0b8068986a01e2d8f449917829753a54f6bd4d1265c2b4ad9cba75560020f"
   name = "github.com/xanzy/ssh-agent"
   packages = ["."]
-  pruneopts = ""
   revision = "640f0ab560aeb89d523bb6ac322b1244d5c3796c"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:4cae11053a5fc8e7b08228fcc14d161d3e60b64ba508a8b216937da472690991"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -362,15 +291,13 @@
     "ssh",
     "ssh/agent",
     "ssh/knownhosts",
-    "ssh/terminal",
+    "ssh/terminal"
   ]
-  pruneopts = ""
   revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
   source = "github.com/golang/crypto"
 
 [[projects]]
   branch = "master"
-  digest = "1:98219b20d296a0031fdb434d30ca6e109623a09530a76cf57e41c94bd1e391a0"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -379,33 +306,27 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace",
+    "trace"
   ]
-  pruneopts = ""
   revision = "c39426892332e1bb5ec0a434a079bf82f5d30c54"
   source = "github.com/golang/net"
 
 [[projects]]
   branch = "master"
-  digest = "1:b2ea75de0ccb2db2ac79356407f8a4cd8f798fe15d41b381c00abf3ae8e55ed1"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
-  pruneopts = ""
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
-  digest = "1:8812fbc18f45708b5580ed61267fefe5eeb29b36773bdfaad48b0843e3810c02"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = ""
   revision = "f0d5e33068cb57c22a181f5df0ffda885309eb5a"
   source = "github.com/golang/sys"
 
 [[projects]]
-  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -421,23 +342,19 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   source = "github.com/golang/text"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3970150423e3f47a6d354b2868f7db632b665463755194aac1a30c4fb341be57"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  pruneopts = ""
   revision = "383e8b2c3b9e36c4076b235b32537292176bae20"
 
 [[projects]]
-  digest = "1:ca75b3775a5d4e5d1fb48f57ef0865b4aaa8b3f00e6b52be68db991c4594e0a7"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -465,37 +382,31 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
+    "tap"
   ]
-  pruneopts = ""
   revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
   version = "v1.14.0"
 
 [[projects]]
-  digest = "1:dcb032b430358a31669b9c4b8665598b493b3fc8c71dbeb4926d279990045966"
   name = "gopkg.in/bblfsh/client-go.v2"
   packages = [
     ".",
-    "tools",
+    "tools"
   ]
-  pruneopts = ""
   revision = "0032d4a7f3de7befa2aa03146153042e44193e82"
   version = "v2.8.5"
 
 [[projects]]
-  digest = "1:e4d06d096b60a4ada8cad171c97127038aff58ddff86285781becae862c409e6"
   name = "gopkg.in/bblfsh/sdk.v1"
   packages = [
     "manifest",
     "protocol",
-    "uast",
+    "uast"
   ]
-  pruneopts = ""
   revision = "94e3b212553e761677da180f321d9a7a60ebec5f"
   version = "v1.16.1"
 
 [[projects]]
-  digest = "1:f9814d0732a6474b6d869fdf7919950d474ec9b5fbfa33859f9087cbabd77090"
   name = "gopkg.in/bblfsh/sdk.v2"
   packages = [
     "driver",
@@ -507,43 +418,35 @@
     "uast/nodes/nodesproto",
     "uast/nodes/nodesproto/pio",
     "uast/role",
-    "uast/transformer",
+    "uast/transformer"
   ]
-  pruneopts = ""
   revision = "966e28c602fb968fc52e27e14762bdf9307da229"
   version = "v2.1.0"
 
 [[projects]]
   branch = "v1"
-  digest = "1:1d01f96bc2293b56c3dec797b8f976d7613fb30ce92bfbc994130404f7f7f031"
   name = "gopkg.in/check.v1"
   packages = ["."]
-  pruneopts = ""
   revision = "788fd78401277ebd861206a03c884797c6ec5541"
 
 [[projects]]
-  digest = "1:88316440c1d0311ce17223ad941eba557289459149172bc16a69cf4f5742d0e6"
   name = "gopkg.in/src-d/enry.v1"
   packages = [
     ".",
     "data",
     "internal/tokenizer",
-    "regex",
+    "regex"
   ]
-  pruneopts = ""
   revision = "15bb13117fb1cc607bf87046d41ac7b53084c18b"
   version = "v1.6.5"
 
 [[projects]]
-  digest = "1:8fcc8d6c614e3411eb0d3ffaea8626f9d70fc04cc38251a586d0c249ca915ad6"
   name = "gopkg.in/src-d/go-billy-siva.v4"
   packages = ["."]
-  pruneopts = ""
   revision = "d388edead67fd7e0df790c57ed58e6dd89dd1634"
   version = "v4.2.0"
 
 [[projects]]
-  digest = "1:6715e0bec216255ab784fe04aa4d5a0a626ae07a3a209080182e469bc142761a"
   name = "gopkg.in/src-d/go-billy.v4"
   packages = [
     ".",
@@ -551,30 +454,24 @@
     "helper/mount",
     "helper/polyfill",
     "osfs",
-    "util",
+    "util"
   ]
-  pruneopts = ""
   revision = "83cf655d40b15b427014d7875d10850f96edba14"
   version = "v4.2.0"
 
 [[projects]]
-  digest = "1:f9eb30e91da24ffb7cac6d5d9611c8f593adc183457d1e92a965fe77bc217c2a"
   name = "gopkg.in/src-d/go-errors.v1"
   packages = ["."]
-  pruneopts = ""
   revision = "8bbbeeb767dfdd053b9b45d5a16a4f4ce2c6f694"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:251a6672526e992d31a9db679a7aa0a2d19b96f95af3417d237d65135ccd0fef"
   name = "gopkg.in/src-d/go-git-fixtures.v3"
   packages = ["."]
-  pruneopts = ""
   revision = "a29d269c3be65e4d1b20c29133c74e0551e1aa5d"
   version = "v3.1.0"
 
 [[projects]]
-  digest = "1:c8d641ccca2d055cd2cb96dd7c8992478f38034a9da2625bd72adb73aaf22f5b"
   name = "gopkg.in/src-d/go-git.v4"
   packages = [
     ".",
@@ -616,14 +513,12 @@
     "utils/merkletrie/filesystem",
     "utils/merkletrie/index",
     "utils/merkletrie/internal/frame",
-    "utils/merkletrie/noder",
+    "utils/merkletrie/noder"
   ]
-  pruneopts = ""
   revision = "5cc316baa64287c7e56cb7372a5046c30fd955c1"
   source = "github.com/src-d/go-git"
 
 [[projects]]
-  digest = "1:33ece2938a9c1c0e72a4262450a1d6a048ae071f275d954aac9ea79e726b7818"
   name = "gopkg.in/src-d/go-mysql-server.v0"
   packages = [
     ".",
@@ -638,22 +533,18 @@
     "sql/index/pilosa",
     "sql/index/pilosalib",
     "sql/parse",
-    "sql/plan",
+    "sql/plan"
   ]
-  pruneopts = ""
   revision = "090a17d38c22a28eccf631f400c11704f65bb6ce"
 
 [[projects]]
-  digest = "1:952e82e2343990fa2bb01e42f13da314e6968b734e87b7b1a76892fab2029fda"
   name = "gopkg.in/src-d/go-siva.v1"
   packages = ["."]
-  pruneopts = ""
   revision = "b4cd504f9d6e57728058609e4540e931fbd41220"
   version = "v1.1.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:26a3c79dd9029585ddd95c428cdea895dde39541fc4652fd827ea68fdb2c9cf2"
   name = "gopkg.in/src-d/go-vitess.v0"
   packages = [
     "bytes2",
@@ -672,81 +563,31 @@
     "vt/proto/vtrpc",
     "vt/sqlparser",
     "vt/vterrors",
-    "vt/vttls",
+    "vt/vttls"
   ]
-  pruneopts = ""
   revision = "2cb632cdef3c332f5cba7f035479213ca31dfe71"
 
 [[projects]]
-  digest = "1:83aacdc3b7d95550b004ce34f9fe68dc50628aa3d2f4e99b5970876b8bb2b1f0"
   name = "gopkg.in/toqueteos/substring.v1"
   packages = ["."]
-  pruneopts = ""
   revision = "c5f61671513240ddf5563635cc4a90e9f3ae4710"
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:ceec7e96590fb8168f36df4795fefe17051d4b0c2acc7ec4e260d8138c4dafac"
   name = "gopkg.in/warnings.v0"
   packages = ["."]
-  pruneopts = ""
   revision = "ec4a0fea49c7b46c2aeb0b51aac55779c607e52b"
   version = "v0.1.2"
 
 [[projects]]
-  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/BurntSushi/toml",
-    "github.com/hashicorp/golang-lru",
-    "github.com/jessevdk/go-flags",
-    "github.com/opentracing/opentracing-go",
-    "github.com/pilosa/go-pilosa",
-    "github.com/sirupsen/logrus",
-    "github.com/stretchr/testify/require",
-    "github.com/uber/jaeger-client-go/config",
-    "google.golang.org/grpc/connectivity",
-    "gopkg.in/bblfsh/client-go.v2",
-    "gopkg.in/bblfsh/client-go.v2/tools",
-    "gopkg.in/bblfsh/sdk.v1/protocol",
-    "gopkg.in/bblfsh/sdk.v1/uast",
-    "gopkg.in/src-d/enry.v1",
-    "gopkg.in/src-d/go-billy-siva.v4",
-    "gopkg.in/src-d/go-billy.v4",
-    "gopkg.in/src-d/go-billy.v4/osfs",
-    "gopkg.in/src-d/go-errors.v1",
-    "gopkg.in/src-d/go-git-fixtures.v3",
-    "gopkg.in/src-d/go-git.v4",
-    "gopkg.in/src-d/go-git.v4/config",
-    "gopkg.in/src-d/go-git.v4/plumbing",
-    "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-    "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-    "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-    "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-    "gopkg.in/src-d/go-git.v4/plumbing/object",
-    "gopkg.in/src-d/go-git.v4/plumbing/storer",
-    "gopkg.in/src-d/go-git.v4/storage/filesystem",
-    "gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit",
-    "gopkg.in/src-d/go-git.v4/utils/ioutil",
-    "gopkg.in/src-d/go-mysql-server.v0",
-    "gopkg.in/src-d/go-mysql-server.v0/server",
-    "gopkg.in/src-d/go-mysql-server.v0/sql",
-    "gopkg.in/src-d/go-mysql-server.v0/sql/analyzer",
-    "gopkg.in/src-d/go-mysql-server.v0/sql/expression",
-    "gopkg.in/src-d/go-mysql-server.v0/sql/expression/function",
-    "gopkg.in/src-d/go-mysql-server.v0/sql/index/pilosa",
-    "gopkg.in/src-d/go-mysql-server.v0/sql/index/pilosalib",
-    "gopkg.in/src-d/go-mysql-server.v0/sql/plan",
-    "gopkg.in/src-d/go-vitess.v0/mysql",
-    "gopkg.in/yaml.v2",
-  ]
+  inputs-digest = "2f333165e1487deeb9e53c4ca495781aabe6a0f61541e6f0d1ef34665e312fe3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/using-gitbase/configuration.md
+++ b/docs/using-gitbase/configuration.md
@@ -13,6 +13,7 @@
 | `GITBASE_TRACE`              | enable jaeger tracing, default disabled                                            |
 | `GITBASE_READONLY`           | allow read queries only, disabling creating and deleting indexes, default disabled |
 | `GITBASE_LANGUAGE_CACHE_SIZE`           | size of the cache for the `language` UDF. The size is the maximum number of elements kept in the cache, 10000 by default |
+| `GITBASE_UAST_CACHE_SIZE`           | size of the cache for the `uast` and `uast_mode` UDFs. The size is the maximum number of elements kept in the cache, 10000 by default |
 
 ### Jaeger tracing variables
 

--- a/internal/function/uast.go
+++ b/internal/function/uast.go
@@ -1,9 +1,13 @@
 package function
 
 import (
+	"crypto/sha1"
 	"fmt"
+	"hash"
 	"strings"
 
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/sirupsen/logrus"
 	bblfsh "gopkg.in/bblfsh/client-go.v2"
 	"gopkg.in/bblfsh/client-go.v2/tools"
 	"gopkg.in/bblfsh/sdk.v1/uast"
@@ -12,109 +16,111 @@ import (
 	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
 )
 
+const defaultUASTCacheSize = 10000
+
+var uastCache *lru.Cache
+
+func init() {
+	var err error
+	uastCache, err = lru.New(defaultUASTCacheSize)
+	if err != nil {
+		panic(fmt.Errorf("cannot initialize UAST cache: %s", err))
+	}
+}
+
 var (
 	// UASTExpressionType represents the returned SQL type by
 	// the functions uast, uast_mode, uast_xpath and uast_children.
 	UASTExpressionType sql.Type = sql.Blob
 )
 
-// UAST returns an array of UAST nodes as blobs.
-type UAST struct {
+// uastFunc shouldn't be used as an sql.Expression itself.
+// It's intended to be embedded in others UAST functions,
+// like UAST and UASTMode.
+type uastFunc struct {
+	Mode  sql.Expression
 	Blob  sql.Expression
 	Lang  sql.Expression
 	XPath sql.Expression
-}
 
-// NewUAST creates a new UAST UDF.
-func NewUAST(args ...sql.Expression) (sql.Expression, error) {
-	var blob, lang, xpath sql.Expression
-	switch len(args) {
-	case 1:
-		blob = args[0]
-	case 2:
-		blob = args[0]
-		lang = args[1]
-	case 3:
-		blob = args[0]
-		lang = args[1]
-		xpath = args[2]
-	default:
-		return nil, sql.ErrInvalidArgumentNumber.New("1, 2, or 3", len(args))
-	}
-	return &UAST{blob, lang, xpath}, nil
+	h        hash.Hash
+	errCache *lru.Cache
 }
 
 // IsNullable implements the Expression interface.
-func (f UAST) IsNullable() bool {
-	return f.Blob.IsNullable() ||
-		(f.Lang != nil && f.Lang.IsNullable()) ||
-		(f.XPath != nil && f.XPath.IsNullable())
+func (u *uastFunc) IsNullable() bool {
+	return u.Blob.IsNullable() || u.Mode.IsNullable() ||
+		(u.Lang != nil && u.Lang.IsNullable()) ||
+		(u.XPath != nil && u.XPath.IsNullable())
 }
 
 // Resolved implements the Expression interface.
-func (f UAST) Resolved() bool {
-	return f.Blob.Resolved() &&
-		(f.Lang == nil || f.Lang.Resolved()) &&
-		(f.XPath == nil || f.XPath.Resolved())
+func (u *uastFunc) Resolved() bool {
+	return u.Blob.Resolved() && u.Mode.Resolved() &&
+		(u.Lang == nil || u.Lang.Resolved()) &&
+		(u.XPath == nil || u.XPath.Resolved())
 }
 
 // Type implements the Expression interface.
-func (f UAST) Type() sql.Type {
+func (u *uastFunc) Type() sql.Type {
 	return UASTExpressionType
 }
 
 // Children implements the Expression interface.
-func (f UAST) Children() []sql.Expression {
-	exprs := []sql.Expression{f.Blob}
-	if f.Lang != nil {
-		exprs = append(exprs, f.Lang)
+func (u *uastFunc) Children() []sql.Expression {
+	exprs := []sql.Expression{u.Blob, u.Mode}
+	if u.Lang != nil {
+		exprs = append(exprs, u.Lang)
 	}
-	if f.XPath != nil {
-		exprs = append(exprs, f.XPath)
+	if u.XPath != nil {
+		exprs = append(exprs, u.XPath)
 	}
 	return exprs
 }
 
 // TransformUp implements the Expression interface.
-func (f UAST) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
+func (u *uastFunc) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
 	var lang, xpath sql.Expression
-	blob, err := f.Blob.TransformUp(fn)
+	mode, err := u.Mode.TransformUp(fn)
 	if err != nil {
 		return nil, err
 	}
 
-	if f.Lang != nil {
-		lang, err = f.Lang.TransformUp(fn)
+	blob, err := u.Blob.TransformUp(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Lang != nil {
+		lang, err = u.Lang.TransformUp(fn)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if f.XPath != nil {
-		xpath, err = f.XPath.TransformUp(fn)
+	if u.XPath != nil {
+		xpath, err = u.XPath.TransformUp(fn)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return fn(&UAST{Blob: blob, Lang: lang, XPath: xpath})
+	tu := *u
+	tu.Mode = mode
+	tu.Blob = blob
+	tu.Lang = lang
+	tu.XPath = xpath
+
+	return fn(&tu)
 }
 
 // String implements the Expression interface.
-func (f UAST) String() string {
-	if f.Lang != nil && f.XPath != nil {
-		return fmt.Sprintf("uast(%s, %s, %s)", f.Blob, f.Lang, f.XPath)
-	}
-
-	if f.Lang != nil {
-		return fmt.Sprintf("uast(%s, %s)", f.Blob, f.Lang)
-	}
-
-	return fmt.Sprintf("uast(%s)", f.Blob)
+func (u *uastFunc) String() string {
+	panic("method String() shouldn't be called directly on an uastFunc")
 }
 
 // Eval implements the Expression interface.
-func (f UAST) Eval(ctx *sql.Context, row sql.Row) (out interface{}, err error) {
+func (u *uastFunc) Eval(ctx *sql.Context, row sql.Row) (out interface{}, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("uast: unknown error: %s", r)
@@ -124,142 +130,10 @@ func (f UAST) Eval(ctx *sql.Context, row sql.Row) (out interface{}, err error) {
 	span, ctx := ctx.Span("gitbase.UAST")
 	defer span.Finish()
 
-	blob, err := f.Blob.Eval(ctx, row)
+	m, err := exprToString(ctx, u.Mode, row)
 	if err != nil {
 		return nil, err
 	}
-
-	if blob == nil {
-		return nil, nil
-	}
-
-	blob, err = sql.Blob.Convert(blob)
-	if err != nil {
-		return nil, err
-	}
-
-	bytes := blob.([]byte)
-
-	lang, err := exprToString(ctx, f.Lang, row)
-	if err != nil {
-		return nil, err
-	}
-
-	lang = strings.ToLower(lang)
-
-	xpath, err := exprToString(ctx, f.XPath, row)
-	if err != nil {
-		return nil, err
-	}
-
-	return getUAST(ctx, bytes, lang, xpath, bblfsh.Semantic)
-}
-
-// UASTMode returns an array of UAST nodes as blobs.
-type UASTMode struct {
-	Mode sql.Expression
-	Blob sql.Expression
-	Lang sql.Expression
-}
-
-// NewUASTMode creates a new UASTMode UDF.
-func NewUASTMode(mode, blob, lang sql.Expression) sql.Expression {
-	return &UASTMode{mode, blob, lang}
-}
-
-// IsNullable implements the Expression interface.
-func (f UASTMode) IsNullable() bool {
-	return f.Blob.IsNullable() && f.Lang.IsNullable() && f.Mode.IsNullable()
-}
-
-// Resolved implements the Expression interface.
-func (f UASTMode) Resolved() bool {
-	return f.Blob.Resolved() && f.Lang.Resolved() && f.Mode.Resolved()
-}
-
-// Type implements the Expression interface.
-func (f UASTMode) Type() sql.Type {
-	return UASTExpressionType
-}
-
-// Children implements the Expression interface.
-func (f UASTMode) Children() []sql.Expression {
-	exprs := []sql.Expression{f.Blob}
-	if f.Lang != nil {
-		exprs = append(exprs, f.Lang)
-	}
-	if f.Mode != nil {
-		exprs = append(exprs, f.Mode)
-	}
-	return exprs
-}
-
-// TransformUp implements the Expression interface.
-func (f UASTMode) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
-	var lang, mode sql.Expression
-	blob, err := f.Blob.TransformUp(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	lang, err = f.Lang.TransformUp(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	mode, err = f.Mode.TransformUp(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	return fn(&UASTMode{Blob: blob, Lang: lang, Mode: mode})
-}
-
-// String implements the Expression interface.
-func (f UASTMode) String() string {
-	return fmt.Sprintf("uast_mode(%s, %s, %s)", f.Mode, f.Blob, f.Lang)
-}
-
-// Eval implements the Expression interface.
-func (f UASTMode) Eval(ctx *sql.Context, row sql.Row) (out interface{}, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("uast_mode: unknown error: %s", r)
-		}
-	}()
-
-	span, ctx := ctx.Span("gitbase.UASTMode")
-	defer span.Finish()
-
-	blob, err := f.Blob.Eval(ctx, row)
-	if err != nil {
-		return nil, err
-	}
-
-	if blob == nil {
-		return nil, nil
-	}
-
-	blob, err = sql.Blob.Convert(blob)
-	if err != nil {
-		return nil, err
-	}
-
-	bytes := blob.([]byte)
-
-	lang, err := exprToString(ctx, f.Lang, row)
-	if err != nil {
-		return nil, err
-	}
-
-	lang = strings.ToLower(lang)
-
-	m, err := exprToString(ctx, f.Mode, row)
-	if err != nil {
-		return nil, err
-	}
-
-	m = strings.ToLower(m)
 
 	var mode bblfsh.Mode
 	switch m {
@@ -273,7 +147,191 @@ func (f UASTMode) Eval(ctx *sql.Context, row sql.Row) (out interface{}, err erro
 		return nil, fmt.Errorf("invalid uast mode %s", m)
 	}
 
-	return getUAST(ctx, bytes, lang, "", mode)
+	blob, err := u.Blob.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if blob == nil {
+		return nil, nil
+	}
+
+	blob, err = sql.Blob.Convert(blob)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes := blob.([]byte)
+	if len(bytes) == 0 {
+		return nil, nil
+	}
+
+	lang, err := exprToString(ctx, u.Lang, row)
+	if err != nil {
+		return nil, err
+	}
+
+	lang = strings.ToLower(lang)
+
+	xpath, err := exprToString(ctx, u.XPath, row)
+	if err != nil {
+		return nil, err
+	}
+
+	return u.getUAST(ctx, bytes, lang, xpath, mode)
+}
+
+func (u *uastFunc) getUAST(
+	ctx *sql.Context,
+	blob []byte,
+	lang, xpath string,
+	mode bblfsh.Mode,
+) (interface{}, error) {
+	key, err := computeKey(u.h, mode.String(), lang, blob)
+	if err != nil {
+		return nil, err
+	}
+
+	var node *uast.Node
+	value, ok := uastCache.Get(key)
+	if ok {
+		node = value.(*uast.Node)
+	} else {
+		if u.errCache != nil {
+			_, ok := u.errCache.Get(key)
+			if ok {
+				return nil, nil
+			}
+		}
+
+		var err error
+		node, err = getUASTFromBblfsh(ctx, blob, lang, xpath, mode)
+		if err != nil {
+			if ErrParseBlob.Is(err) {
+				u.errCache.Add(key, struct{}{})
+				return nil, nil
+			}
+
+			return nil, err
+		}
+
+		uastCache.Add(key, node)
+	}
+
+	var nodes []*uast.Node
+	if xpath == "" {
+		nodes = []*uast.Node{node}
+	} else {
+		var err error
+		nodes, err = tools.Filter(node, xpath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return marshalNodes(ctx, nodes)
+}
+
+// UAST returns an array of UAST nodes as blobs.
+type UAST struct {
+	*uastFunc
+}
+
+var _ sql.Expression = (*UAST)(nil)
+
+// NewUAST creates a new UAST UDF.
+func NewUAST(args ...sql.Expression) (sql.Expression, error) {
+	var mode = expression.NewLiteral("semantic", sql.Text)
+	var blob, lang, xpath sql.Expression
+
+	switch len(args) {
+	default:
+		return nil, sql.ErrInvalidArgumentNumber.New("1, 2, or 3", len(args))
+	case 3:
+		xpath = args[2]
+		fallthrough
+	case 2:
+		lang = args[1]
+		fallthrough
+	case 1:
+		blob = args[0]
+	}
+
+	errCache, err := lru.New(defaultUASTCacheSize)
+	if err != nil {
+		logrus.Warn("couldn't initialize UAST cache for errors")
+	}
+
+	return &UAST{&uastFunc{
+		Mode:     mode,
+		Blob:     blob,
+		Lang:     lang,
+		XPath:    xpath,
+		h:        sha1.New(),
+		errCache: errCache,
+	}}, nil
+}
+
+// TransformUp implements the Expression interface.
+func (u *UAST) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
+	uf, err := u.uastFunc.TransformUp(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	return fn(&UAST{uf.(*uastFunc)})
+}
+
+// String implements the Expression interface.
+func (u *UAST) String() string {
+	if u.Lang != nil && u.XPath != nil {
+		return fmt.Sprintf("uast(%s, %s, %s)", u.Blob, u.Lang, u.XPath)
+	}
+
+	if u.Lang != nil {
+		return fmt.Sprintf("uast(%s, %s)", u.Blob, u.Lang)
+	}
+
+	return fmt.Sprintf("uast(%s)", u.Blob)
+}
+
+// UASTMode returns an array of UAST nodes as blobs.
+type UASTMode struct {
+	*uastFunc
+}
+
+var _ sql.Expression = (*UASTMode)(nil)
+
+// NewUASTMode creates a new UASTMode UDF.
+func NewUASTMode(mode, blob, lang sql.Expression) sql.Expression {
+	errCache, err := lru.New(defaultUASTCacheSize)
+	if err != nil {
+		logrus.Warn("couldn't initialize UAST cache for errors")
+	}
+
+	return &UASTMode{&uastFunc{
+		Mode:     mode,
+		Blob:     blob,
+		Lang:     lang,
+		XPath:    nil,
+		h:        sha1.New(),
+		errCache: errCache,
+	}}
+}
+
+// TransformUp implements the Expression interface.
+func (u *UASTMode) TransformUp(fn sql.TransformExprFunc) (sql.Expression, error) {
+	uf, err := u.uastFunc.TransformUp(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	return fn(&UASTMode{uf.(*uastFunc)})
+}
+
+// String implements the Expression interface.
+func (u *UASTMode) String() string {
+	return fmt.Sprintf("uast_mode(%s, %s, %s)", u.Mode, u.Blob, u.Lang)
 }
 
 // UASTXPath performs an XPath query over the given UAST nodes.

--- a/internal/function/uast_test.go
+++ b/internal/function/uast_test.go
@@ -32,11 +32,11 @@ func TestUASTMode(t *testing.T) {
 	ctx, cleanup := setup(t)
 	defer cleanup()
 
-	mode := &UASTMode{
-		Mode: expression.NewGetField(0, sql.Text, "", false),
-		Blob: expression.NewGetField(1, sql.Blob, "", false),
-		Lang: expression.NewGetField(2, sql.Text, "", false),
-	}
+	mode := NewUASTMode(
+		expression.NewGetField(0, sql.Text, "", false),
+		expression.NewGetField(1, sql.Blob, "", false),
+		expression.NewGetField(2, sql.Text, "", false),
+	)
 
 	oldSerialization := []bool{true, false}
 	for _, s := range oldSerialization {
@@ -48,7 +48,7 @@ func TestUASTMode(t *testing.T) {
 		u, _ := bblfshFixtures(t, ctx)
 		testCases := []struct {
 			name     string
-			fn       *UASTMode
+			fn       sql.Expression
 			row      sql.Row
 			expected interface{}
 		}{
@@ -73,20 +73,23 @@ func TestUAST(t *testing.T) {
 	ctx, cleanup := setup(t)
 	defer cleanup()
 
-	fn1 := &UAST{
-		Blob: expression.NewGetField(0, sql.Blob, "", false),
-	}
+	fn1, err := NewUAST(
+		expression.NewGetField(0, sql.Blob, "", false),
+	)
+	require.NoError(t, err)
 
-	fn2 := &UAST{
-		Blob: expression.NewGetField(0, sql.Blob, "", false),
-		Lang: expression.NewGetField(1, sql.Text, "", false),
-	}
+	fn2, err := NewUAST(
+		expression.NewGetField(0, sql.Blob, "", false),
+		expression.NewGetField(1, sql.Text, "", false),
+	)
+	require.NoError(t, err)
 
-	fn3 := &UAST{
-		Blob:  expression.NewGetField(0, sql.Blob, "", false),
-		Lang:  expression.NewGetField(1, sql.Text, "", false),
-		XPath: expression.NewGetField(2, sql.Text, "", false),
-	}
+	fn3, err := NewUAST(
+		expression.NewGetField(0, sql.Blob, "", false),
+		expression.NewGetField(1, sql.Text, "", false),
+		expression.NewGetField(2, sql.Text, "", false),
+	)
+	require.NoError(t, err)
 
 	oldSerialization := []bool{true, false}
 	for _, s := range oldSerialization {
@@ -101,7 +104,7 @@ func TestUAST(t *testing.T) {
 
 		testCases := []struct {
 			name     string
-			fn       *UAST
+			fn       sql.Expression
 			row      sql.Row
 			expected interface{}
 		}{

--- a/internal/function/uast_utils.go
+++ b/internal/function/uast_utils.go
@@ -2,7 +2,6 @@ package function
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"hash"
@@ -64,7 +63,7 @@ func computeKey(h hash.Hash, mode, lang string, blob []byte) (string, error) {
 		return "", err
 	}
 
-	return base64.URLEncoding.EncodeToString(h.Sum(nil)), nil
+	return string(h.Sum(nil)), nil
 }
 
 func writeToHash(h hash.Hash, elements [][]byte) error {

--- a/internal/function/uast_utils.go
+++ b/internal/function/uast_utils.go
@@ -2,14 +2,16 @@ package function
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/binary"
+	"fmt"
+	"hash"
 	"io"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/src-d/gitbase"
 	bblfsh "gopkg.in/bblfsh/client-go.v2"
-	"gopkg.in/bblfsh/client-go.v2/tools"
 	"gopkg.in/bblfsh/sdk.v1/uast"
 	errors "gopkg.in/src-d/go-errors.v1"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
@@ -52,12 +54,40 @@ func exprToString(
 	return x.(string), nil
 }
 
-func getUAST(
-	ctx *sql.Context,
-	bytes []byte,
+func computeKey(h hash.Hash, mode, lang string, blob []byte) (string, error) {
+	h.Reset()
+	if err := writeToHash(h, [][]byte{
+		[]byte(mode),
+		[]byte(lang),
+		blob,
+	}); err != nil {
+		return "", err
+	}
+
+	return base64.URLEncoding.EncodeToString(h.Sum(nil)), nil
+}
+
+func writeToHash(h hash.Hash, elements [][]byte) error {
+	for _, e := range elements {
+		n, err := h.Write(e)
+		if err != nil {
+			return err
+		}
+
+		if n != len(e) {
+			return fmt.Errorf("cache key hash: " +
+				"couldn't write all the content")
+		}
+	}
+
+	return nil
+}
+
+func getUASTFromBblfsh(ctx *sql.Context,
+	blob []byte,
 	lang, xpath string,
 	mode bblfsh.Mode,
-) (interface{}, error) {
+) (*uast.Node, error) {
 	session, ok := ctx.Session.(*gitbase.Session)
 	if !ok {
 		return nil, gitbase.ErrInvalidGitbaseSession.New(ctx.Session)
@@ -81,27 +111,20 @@ func getUAST(
 		}
 	}
 
-	resp, err := client.ParseWithMode(ctx, mode, lang, bytes)
+	resp, err := client.ParseWithMode(ctx, mode, lang, blob)
 	if err != nil {
-		logrus.Warn(ErrParseBlob.New(err))
-		return nil, nil
+		err := ErrParseBlob.New(err)
+		logrus.Warn(err)
+		return nil, err
 	}
 
 	if len(resp.Errors) > 0 {
-		logrus.Warn(ErrParseBlob.New(strings.Join(resp.Errors, "\n")))
+		err := ErrParseBlob.New(strings.Join(resp.Errors, "\n"))
+		logrus.Warn(err)
+		return nil, err
 	}
 
-	var nodes []*uast.Node
-	if xpath == "" {
-		nodes = []*uast.Node{resp.UAST}
-	} else {
-		nodes, err = tools.Filter(resp.UAST, xpath)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return marshalNodes(ctx, nodes)
+	return resp.UAST, nil
 }
 
 func marshalNodes(ctx *sql.Context, nodes []*uast.Node) (data interface{}, err error) {
@@ -192,6 +215,10 @@ func nodesFromBlobArray(data interface{}) ([]*uast.Node, error) {
 	}
 
 	arr := data.([]interface{})
+	if len(arr) == 0 {
+		return nil, nil
+	}
+
 	var nodes = make([]*uast.Node, len(arr))
 	for i, n := range arr {
 		node := uast.NewNode()
@@ -219,6 +246,10 @@ func nodesFromBlob(data interface{}) ([]*uast.Node, error) {
 }
 
 func unmarshalNodes(data []byte) ([]*uast.Node, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
 	nodes := []*uast.Node{}
 	buf := bytes.NewBuffer(data)
 	for {


### PR DESCRIPTION
This PR adds ~~two caches~~ one cache for the functions `uast` and  `uast_mode`. 

The main cache is set at server level, so it is shared by all the queries. It's caching UASTs requested to bblfsh

~~Meanwhile, the second cache is used at query level and it caches the parsed errors from bblfsh. I thought it makes sense in the context of the same query, that if bblfsh returns a parsed error for a blob, most probably it will return the same error for that blob during the execution of the that query.~~

Results of theses changes running this query
> select file_path,uast(blob_content,language(file_path)) from files limit 100000;

on  a set of 20 siva-files with cache sizes of `10000` are:
- `12 min 43.18 sec` -> NO CACHE
- `4 min 13.12 sec` -> CACHE
- ~~`12 min 30.88 sec` -> NO CACHE~~
- ~~`3 min 56.06 sec` -> CACHE UASTs~~
- ~~`1 min 2.60 sec` -> CACHE UASTs and Errors~~
- ~~`59.21 sec` -> CACHE UASTs and Errors with new uast serialization~~

Other non-directly related change is that I've refactored the code for `UAST` and `UASTMode` functions. They are almos the same, so the code was starting to be too much duplicated. Now both of them have an `uastFunc` struct embedded which keeps almost all the implementation. The `UAST` and `UASTMode` functions just implement the constructors and the `TransformUp` and `String` methods.