### PR TITLE
update docker installation text

### DIFF
--- a/docs/using-gitbase/getting-started.md
+++ b/docs/using-gitbase/getting-started.md
@@ -39,7 +39,7 @@ $ make dependencies
 
 ## Running with docker
 
-You can use the official image from [docker hub](https://hub.docker.com/r/srcd/gitbase/tags/) to quickly run gitbase:
+You can use the official image from [docker hub](https://hub.docker.com/r/srcd/gitbase/tags/) to quickly run gitbase, where ```/my/git/repos``` should be replaced by your local git directory:
 ```
 $ docker run --rm --name gitbase -p 3306:3306 -v /my/git/repos:/opt/repos srcd/gitbase:latest
 ```


### PR DESCRIPTION
I hadn't noticed that ```/my/git/repos``` should be replaced by my git directory until @jfontan told me, and I thought it might be useful for users that might not read carefully the command.

Signed-off-by: tsolakou <tsolakou.a@gmail.com>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->