### PR TITLE
*: pushdown projections properly in the files table

### DIFF
--- a/files.go
+++ b/files.go
@@ -46,7 +46,9 @@ func (r *filesTable) WithFilters(filters []sql.Expression) sql.Table {
 }
 
 func (r *filesTable) WithProjection(colNames []string) sql.Table {
-	return r
+	nt := *r
+	nt.projection = colNames
+	return &nt
 }
 
 func (r *filesTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {


### PR DESCRIPTION
Closes #473 

Projections weren't pushdowned in the `files` table. This table needs to get the column `blob_content` pushdowned to read the blobs' content, that's why this column was returning nothing.