### PR TITLE
gitbase: implement sql.PartitionCounter in all tables

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -26,6 +26,7 @@ var (
 )
 
 type blobsTable struct {
+	partitioned
 	filters    []sql.Expression
 	projection []string
 	index      sql.IndexLookup
@@ -82,10 +83,6 @@ func (r *blobsTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 func (r *blobsTable) IndexLookup() sql.IndexLookup { return r.index }
 func (r *blobsTable) Filters() []sql.Expression    { return r.filters }
 func (r *blobsTable) Projection() []string         { return r.projection }
-
-func (r *blobsTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (r *blobsTable) PartitionRows(
 	ctx *sql.Context,

--- a/commit_blobs.go
+++ b/commit_blobs.go
@@ -10,6 +10,7 @@ import (
 )
 
 type commitBlobsTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -54,10 +55,6 @@ func (t *commitBlobsTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 
 func (t *commitBlobsTable) IndexLookup() sql.IndexLookup { return t.index }
 func (t *commitBlobsTable) Filters() []sql.Expression    { return t.filters }
-
-func (t *commitBlobsTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (t *commitBlobsTable) PartitionRows(
 	ctx *sql.Context,

--- a/commit_files.go
+++ b/commit_files.go
@@ -14,6 +14,7 @@ import (
 )
 
 type commitFilesTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -59,10 +60,6 @@ func (t *commitFilesTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 
 func (t *commitFilesTable) IndexLookup() sql.IndexLookup { return t.index }
 func (t *commitFilesTable) Filters() []sql.Expression    { return t.filters }
-
-func (t *commitFilesTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (t *commitFilesTable) PartitionRows(
 	ctx *sql.Context,

--- a/commit_trees.go
+++ b/commit_trees.go
@@ -12,6 +12,7 @@ import (
 )
 
 type commitTreesTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -55,10 +56,6 @@ func (t *commitTreesTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 
 func (t *commitTreesTable) IndexLookup() sql.IndexLookup { return t.index }
 func (t *commitTreesTable) Filters() []sql.Expression    { return t.filters }
-
-func (t *commitTreesTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (t *commitTreesTable) PartitionRows(
 	ctx *sql.Context,

--- a/commits.go
+++ b/commits.go
@@ -10,6 +10,7 @@ import (
 )
 
 type commitsTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -65,10 +66,6 @@ func (r *commitsTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 
 func (r *commitsTable) IndexLookup() sql.IndexLookup { return r.index }
 func (r *commitsTable) Filters() []sql.Expression    { return r.filters }
-
-func (r *commitsTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (r *commitsTable) PartitionRows(
 	ctx *sql.Context,

--- a/files.go
+++ b/files.go
@@ -11,6 +11,7 @@ import (
 )
 
 type filesTable struct {
+	partitioned
 	filters    []sql.Expression
 	projection []string
 	index      sql.IndexLookup
@@ -60,10 +61,6 @@ func (r *filesTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 func (r *filesTable) IndexLookup() sql.IndexLookup { return r.index }
 func (r *filesTable) Filters() []sql.Expression    { return r.filters }
 func (r *filesTable) Projection() []string         { return r.projection }
-
-func (r *filesTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (r *filesTable) PartitionRows(
 	ctx *sql.Context,

--- a/ref_commits.go
+++ b/ref_commits.go
@@ -13,6 +13,7 @@ import (
 )
 
 type refCommitsTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -58,10 +59,6 @@ func (t *refCommitsTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 
 func (t *refCommitsTable) IndexLookup() sql.IndexLookup { return t.index }
 func (t *refCommitsTable) Filters() []sql.Expression    { return t.filters }
-
-func (t *refCommitsTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (t *refCommitsTable) PartitionRows(
 	ctx *sql.Context,

--- a/references.go
+++ b/references.go
@@ -14,6 +14,7 @@ import (
 )
 
 type referencesTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -61,10 +62,6 @@ func (r *referencesTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 
 func (r *referencesTable) IndexLookup() sql.IndexLookup { return r.index }
 func (r *referencesTable) Filters() []sql.Expression    { return r.filters }
-
-func (r *referencesTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (r *referencesTable) PartitionRows(
 	ctx *sql.Context,

--- a/remotes.go
+++ b/remotes.go
@@ -10,6 +10,7 @@ import (
 )
 
 type remotesTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -60,10 +61,6 @@ func (r *remotesTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 
 func (r *remotesTable) IndexLookup() sql.IndexLookup { return r.index }
 func (r *remotesTable) Filters() []sql.Expression    { return r.filters }
-
-func (r *remotesTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (r *remotesTable) PartitionRows(
 	ctx *sql.Context,

--- a/repositories.go
+++ b/repositories.go
@@ -7,6 +7,7 @@ import (
 )
 
 type repositoriesTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -52,10 +53,6 @@ func (r *repositoriesTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 	nt := *r
 	nt.index = idx
 	return &nt
-}
-
-func (r *repositoriesTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
 }
 
 func (r *repositoriesTable) PartitionRows(

--- a/squash.go
+++ b/squash.go
@@ -10,6 +10,7 @@ import (
 // SquashedTable is a table that combines the output of some tables as the
 // inputs of others with chaining so it's less expensive to compute.
 type SquashedTable struct {
+	partitioned
 	iter           ChainableIter
 	tables         []string
 	schemaMappings []int
@@ -26,10 +27,17 @@ func NewSquashedTable(
 	indexedTables []string,
 	tables ...string,
 ) *SquashedTable {
-	return &SquashedTable{iter, tables, mapping, filters, indexedTables, nil}
+	return &SquashedTable{
+		iter:           iter,
+		tables:         tables,
+		schemaMappings: mapping,
+		filters:        filters,
+		indexedTables:  indexedTables,
+	}
 }
 
 var _ sql.Table = (*SquashedTable)(nil)
+var _ sql.PartitionCounter = (*SquashedTable)(nil)
 
 // Name implements the sql.Table interface.
 func (t *SquashedTable) Name() string {
@@ -51,11 +59,6 @@ func (t *SquashedTable) Schema() sql.Schema {
 	}
 
 	return t.schema
-}
-
-// Partitions implements the sql.Table interface.
-func (t *SquashedTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
 }
 
 // PartitionRows implements the sql.Table interface.

--- a/table.go
+++ b/table.go
@@ -9,6 +9,7 @@ import (
 // Table represents a gitbase table.
 type Table interface {
 	sql.FilteredTable
+	sql.PartitionCounter
 	gitBase
 }
 

--- a/tree_entries.go
+++ b/tree_entries.go
@@ -12,6 +12,7 @@ import (
 )
 
 type treeEntriesTable struct {
+	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
 }
@@ -57,10 +58,6 @@ func (r *treeEntriesTable) WithIndexLookup(idx sql.IndexLookup) sql.Table {
 
 func (r *treeEntriesTable) IndexLookup() sql.IndexLookup { return r.index }
 func (r *treeEntriesTable) Filters() []sql.Expression    { return r.filters }
-
-func (r *treeEntriesTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
-	return newRepositoryPartitionIter(ctx)
-}
 
 func (r *treeEntriesTable) PartitionRows(
 	ctx *sql.Context,


### PR DESCRIPTION
Closes #477 

Since `Partitions` and `PartitionCount` is always the same for all tables, just moved them into a `partitioned` helper which can be embedded to avoid having so much repeated code.