### PR TITLE
gitbase: close siva FS after use

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -396,6 +396,15 @@ func (i *blobsKeyValueIter) Close() error {
 	if i.blobs != nil {
 		i.blobs.Close()
 	}
+
+	if i.idx != nil {
+		i.idx.Close()
+	}
+
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return nil
 }
 

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -236,3 +236,11 @@ func TestBlobsIndex(t *testing.T) {
 		)},
 	)
 }
+
+func TestBlobsIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(blobsTable))
+}
+
+func TestBlobsIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(blobsTable))
+}

--- a/commit_files.go
+++ b/commit_files.go
@@ -301,6 +301,10 @@ func (i *commitFilesRowIter) Close() error {
 		i.files.Close()
 	}
 
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	if i.index != nil {
 		return i.index.Close()
 	}
@@ -486,6 +490,14 @@ func (i *commitFilesKeyValueIter) Close() error {
 
 	if i.files != nil {
 		i.files.Close()
+	}
+
+	if i.idx != nil {
+		i.idx.Close()
+	}
+
+	if i.repo != nil {
+		i.repo.Close()
 	}
 
 	return nil

--- a/commit_files_test.go
+++ b/commit_files_test.go
@@ -98,3 +98,11 @@ func TestEncodeCommitFileIndexKey(t *testing.T) {
 
 	require.Equal(k, k2)
 }
+
+func TestCommitFilesIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(commitFilesTable))
+}
+
+func TestCommitFilesIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(commitFilesTable))
+}

--- a/commit_trees_test.go
+++ b/commit_trees_test.go
@@ -168,3 +168,11 @@ func TestCommitTreesRowKeyMapper(t *testing.T) {
 
 	require.Equal(row, row2)
 }
+
+func TestCommitTreesIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(commitTreesTable))
+}
+
+func TestCommitTreesIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(commitTreesTable))
+}

--- a/commits.go
+++ b/commits.go
@@ -190,7 +190,9 @@ func (i *commitIter) Close() error {
 		i.iter.Close()
 	}
 
-	i.repo.Close()
+	if i.repo != nil {
+		i.repo.Close()
+	}
 
 	return nil
 }
@@ -274,6 +276,10 @@ func (i *commitsByHashIter) ForEach(f func(*object.Commit) error) error {
 func (i *commitsByHashIter) Close() {
 	if i.commitIter != nil {
 		i.commitIter.Close()
+	}
+
+	if i.repo != nil {
+		i.repo.Close()
 	}
 }
 
@@ -374,6 +380,15 @@ func (i *commitsKeyValueIter) Close() error {
 	if i.commits != nil {
 		i.commits.Close()
 	}
+
+	if i.idx != nil {
+		i.idx.Close()
+	}
+
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return nil
 }
 

--- a/commits_test.go
+++ b/commits_test.go
@@ -298,3 +298,11 @@ func TestCommitsIndex(t *testing.T) {
 		)},
 	)
 }
+
+func TestCommitsIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(commitsTable))
+}
+
+func TestCommitsIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(commitsTable))
+}

--- a/common_test.go
+++ b/common_test.go
@@ -2,11 +2,22 @@ package gitbase
 
 import (
 	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-billy-siva.v4"
+	billy "gopkg.in/src-d/go-billy.v4"
+	"gopkg.in/src-d/go-billy.v4/osfs"
 	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
+	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing/cache"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
 )
@@ -64,4 +75,181 @@ func buildSession(t *testing.T, repos fixtures.Fixtures,
 
 func tableToRows(ctx *sql.Context, t sql.Table) ([]sql.Row, error) {
 	return sql.NodeToRows(ctx, plan.NewResolvedTable(t))
+}
+
+/*
+
+The following code adds utilities to test that siva files are properly closed.
+Instead of using normal setup you can use setupSivaCloseRepos, it returns
+a context with a pool with all the sivas in "_testdata" directory. It also
+tracks all siva filesystems opened. Its closed state can be checked with
+closedSiva.Check().
+
+*/
+
+type closedSiva struct {
+	closed []bool
+	m      sync.Mutex
+}
+
+func (c *closedSiva) NewFS(path string) (billy.Filesystem, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	localfs := osfs.New(filepath.Dir(path))
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "gitbase-siva")
+	if err != nil {
+		return nil, err
+	}
+
+	tmpfs := osfs.New(tmpDir)
+
+	fs, err := sivafs.NewFilesystem(localfs, filepath.Base(path), tmpfs)
+	if err != nil {
+		return nil, err
+	}
+
+	pos := len(c.closed)
+	c.closed = append(c.closed, false)
+
+	fun := func() {
+		c.m.Lock()
+		defer c.m.Unlock()
+		c.closed[pos] = true
+	}
+
+	return &closedSivaFilesystem{fs, fun}, nil
+}
+
+func (c *closedSiva) Check() bool {
+	for _, f := range c.closed {
+		if !f {
+			return false
+		}
+	}
+
+	return true
+}
+
+type closedSivaFilesystem struct {
+	sivafs.SivaFS
+	closeFunc func()
+}
+
+func (c *closedSivaFilesystem) Sync() error {
+	if c.closeFunc != nil {
+		c.closeFunc()
+	}
+
+	return c.SivaFS.Sync()
+}
+
+var _ repository = new(closedSivaRepository)
+
+type closedSivaRepository struct {
+	path  string
+	siva  *closedSiva
+	cache cache.Object
+}
+
+func (c *closedSivaRepository) ID() string {
+	return c.path
+}
+
+func (c *closedSivaRepository) Repo() (*Repository, error) {
+	fs, err := c.FS()
+	if err != nil {
+		return nil, err
+	}
+
+	s := fs.(*closedSivaFilesystem)
+	closeFunc := func() { s.Sync() }
+
+	sto := filesystem.NewStorageWithOptions(fs, c.Cache(), gitStorerOptions)
+	repo, err := git.Open(sto, nil)
+	if err != nil {
+		return nil, err
+
+	}
+
+	return NewRepository(c.path, repo, closeFunc), nil
+}
+
+func (c *closedSivaRepository) FS() (billy.Filesystem, error) {
+	return c.siva.NewFS(c.path)
+}
+
+func (c *closedSivaRepository) Path() string {
+	return c.path
+}
+
+func (c *closedSivaRepository) Cache() cache.Object {
+	if c.cache == nil {
+		c.cache = cache.NewObjectLRUDefault()
+	}
+
+	return c.cache
+}
+
+// setupSivaCloseRepos creates a pool with siva files that can be checked
+// if they've been closed.
+func setupSivaCloseRepos(t *testing.T, dir string) (*sql.Context, *closedSiva) {
+	require := require.New(t)
+
+	t.Helper()
+
+	cs := new(closedSiva)
+	pool := NewRepositoryPool(cache.DefaultMaxSize)
+
+	filepath.Walk(dir,
+		func(path string, info os.FileInfo, err error) error {
+			if strings.HasSuffix(path, ".siva") {
+				repo := &closedSivaRepository{path: path, siva: cs}
+				err := pool.Add(repo)
+				require.NoError(err)
+			}
+
+			return nil
+		},
+	)
+
+	session := NewSession(pool, WithSkipGitErrors(true))
+	ctx := sql.NewContext(context.TODO(), sql.WithSession(session))
+
+	return ctx, cs
+}
+
+func testTableIndexIterClosed(t *testing.T, table sql.IndexableTable) {
+	t.Helper()
+
+	require := require.New(t)
+	ctx, closed := setupSivaCloseRepos(t, "_testdata")
+
+	iter, err := table.IndexKeyValues(ctx, nil)
+	require.NoError(err)
+
+	for {
+		_, i, err := iter.Next()
+		if err != nil {
+			require.Equal(io.EOF, err)
+			break
+		}
+
+		i.Close()
+	}
+
+	iter.Close()
+	require.True(closed.Check())
+}
+
+func testTableIterClosed(t *testing.T, table sql.IndexableTable) {
+	t.Helper()
+
+	require := require.New(t)
+	ctx, closed := setupSivaCloseRepos(t, "_testdata")
+	_, err := tableToRows(ctx, table)
+	require.NoError(err)
+
+	require.True(closed.Check())
 }

--- a/files.go
+++ b/files.go
@@ -492,6 +492,14 @@ func (i *filesKeyValueIter) Close() error {
 		i.files.Close()
 	}
 
+	if i.idx != nil {
+		i.idx.Close()
+	}
+
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return nil
 }
 

--- a/files_test.go
+++ b/files_test.go
@@ -841,3 +841,11 @@ func TestEncodeFileIndexKey(t *testing.T) {
 
 	require.Equal(k, k3)
 }
+
+func TestFilesIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(filesTable))
+}
+
+func TestFilesIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(filesTable))
+}

--- a/fs_error_test.go
+++ b/fs_error_test.go
@@ -140,7 +140,7 @@ func (r *billyRepository) Repo() (*Repository, error) {
 		return nil, err
 	}
 
-	return NewRepository(r.id, repo), nil
+	return NewRepository(r.id, repo, nil), nil
 }
 
 func (r *billyRepository) FS() (billy.Filesystem, error) {

--- a/packfiles_test.go
+++ b/packfiles_test.go
@@ -14,7 +14,11 @@ var testSivaFilePath = filepath.Join("_testdata", "fff7062de8474d10a67d417ccea87
 func TestRepositoryPackfiles(t *testing.T) {
 	require := require.New(t)
 
-	fs, packfiles, err := repositoryPackfiles(sivaRepo("siva", testSivaFilePath, cache.NewObjectLRUDefault()))
+	repo := sivaRepo("siva", testSivaFilePath, cache.NewObjectLRUDefault())
+	f, err := repo.FS()
+	require.NoError(err)
+
+	fs, packfiles, err := repositoryPackfiles(f)
 
 	require.NoError(err)
 	require.Equal([]plumbing.Hash{

--- a/ref_commits_test.go
+++ b/ref_commits_test.go
@@ -182,3 +182,11 @@ func TestRefCommitsRowKeyMapper(t *testing.T) {
 
 	require.Equal(row, row2)
 }
+
+func TestRefCommitsIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(refCommitsTable))
+}
+
+func TestRefCommitsIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(refCommitsTable))
+}

--- a/references.go
+++ b/references.go
@@ -317,6 +317,8 @@ func (i *refRowIter) Close() error {
 		return i.index.Close()
 	}
 
+	i.repo.Close()
+
 	return nil
 }
 

--- a/references_test.go
+++ b/references_test.go
@@ -131,3 +131,11 @@ func TestRefRowKeyMapper(t *testing.T) {
 
 	require.Equal(row, row2)
 }
+
+func TestReferencesIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(referencesTable))
+}
+
+func TestReferencesIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(referencesTable))
+}

--- a/remotes.go
+++ b/remotes.go
@@ -144,7 +144,7 @@ func (i *remotesRowIter) Next() (sql.Row, error) {
 	remote := i.remotes[i.remotePos]
 	config := remote.Config()
 
-	if i.urlPos >= len(config.URLs) {
+	if i.urlPos >= len(config.URLs) || i.urlPos >= len(config.Fetch) {
 		i.remotePos++
 		if i.remotePos >= len(i.remotes) {
 			return nil, io.EOF
@@ -162,6 +162,10 @@ func (i *remotesRowIter) Next() (sql.Row, error) {
 }
 
 func (i *remotesRowIter) Close() error {
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return nil
 }
 
@@ -268,6 +272,10 @@ func (i *remotesKeyValueIter) Next() ([]interface{}, []byte, error) {
 }
 
 func (i *remotesKeyValueIter) Close() error {
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return nil
 }
 
@@ -296,4 +304,10 @@ func (i *remotesIndexIter) Next() (sql.Row, error) {
 	return remoteToRow(key.Repository, config, key.URLPos), nil
 }
 
-func (i *remotesIndexIter) Close() error { return i.index.Close() }
+func (i *remotesIndexIter) Close() error {
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
+	return i.index.Close()
+}

--- a/remotes_test.go
+++ b/remotes_test.go
@@ -145,3 +145,11 @@ func TestEncodeRemoteIndexKey(t *testing.T) {
 	require.NoError(k2.decode(data))
 	require.Equal(k, k2)
 }
+
+func TestRemotesIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(remotesTable))
+}
+
+func TestRemotesIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(remotesTable))
+}

--- a/repository_pool_test.go
+++ b/repository_pool_test.go
@@ -18,12 +18,12 @@ func TestRepository(t *testing.T) {
 	require := require.New(t)
 
 	gitRepo := &git.Repository{}
-	repo := NewRepository("identifier", gitRepo)
+	repo := NewRepository("identifier", gitRepo, nil)
 
 	require.Equal("identifier", repo.ID)
 	require.Equal(gitRepo, repo.Repository)
 
-	repo = NewRepository("/other/path", nil)
+	repo = NewRepository("/other/path", nil, nil)
 
 	require.Equal("/other/path", repo.ID)
 	require.Nil(repo.Repository)

--- a/tree_entries.go
+++ b/tree_entries.go
@@ -405,6 +405,15 @@ func (i *treeEntriesKeyValueIter) Close() error {
 	if i.trees != nil {
 		i.trees.Close()
 	}
+
+	if i.idx != nil {
+		i.idx.Close()
+	}
+
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return nil
 }
 

--- a/tree_entries_test.go
+++ b/tree_entries_test.go
@@ -683,3 +683,11 @@ func TestEncodeTreeEntriesIndexKey(t *testing.T) {
 
 	require.Equal(k, k3)
 }
+
+func TestTreeEntriesIndexIterClosed(t *testing.T) {
+	testTableIndexIterClosed(t, new(treeEntriesTable))
+}
+
+func TestTreeEntriesIterClosed(t *testing.T) {
+	testTableIterClosed(t, new(treeEntriesTable))
+}


### PR DESCRIPTION
When using siva filesystems the FS itself was closed by the garbage
collector. This caused to reach opened files limit when the tables did not
trigger garbage collection for some time. One of these cases is getting
remotes:

    select * from remotes;

Now when opening a siva FS a function is added to the repository to
close it.

Also added tests to check that the files are indeed closed. `repository`
and go-billy-siva are mocked to keep track of opened files.

Fixes: #490 