### PR TITLE
Static build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,8 @@ jobs:
 
       before_deploy:
         - make packages
-
-      after_deploy:
         - DOCKER_PUSH_LATEST=1 make docker-push
+        - make static-package
 
       deploy:
         provider: releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.10 as builder
+FROM golang:1.11-alpine as builder
 
 RUN mkdir -p /go/src/github.com/src-d/gitbase
 WORKDIR /go/src/github.com/src-d/gitbase
 COPY . .
 
-RUN apt-get update && apt-get install libxml2-dev -y
+RUN apk add --update libxml2-dev git make bash gcc g++ curl oniguruma-dev
 RUN go get github.com/golang/dep/...
 RUN dep ensure
 RUN cd vendor/gopkg.in/bblfsh/client-go.v2 && make dependencies
-RUN go install -v github.com/src-d/gitbase/...
+RUN go install -v -tags oniguruma -ldflags "-linkmode external -extldflags '-static -lz'" github.com/src-d/gitbase/...
 
-FROM ubuntu:16.04
+FROM alpine:3.8
 
 COPY --from=builder /go/bin/gitbase /bin
 RUN mkdir -p /opt/repos
@@ -21,13 +21,8 @@ ENV GITBASE_REPOS=/opt/repos
 EXPOSE 3306
 
 ENV TINI_VERSION v0.17.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
 RUN chmod +x /tini
-
-RUN apt-get update \
-    && apt-get install libxml2-dev git -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,13 @@ dependencies: bblfsh-client
 
 upgrade:
 	go run tools/rev-upgrade/main.go -p $(UPGRADE_PRJ) -r $(UPGRADE_REV)
+
+static-package:
+	PACKAGE_NAME=gitbase_$(VERSION)_static_linux_amd64 ; \
+	docker rm gitbase-temp ; \
+	docker create --rm --name gitbase-temp $(DOCKER_ORG)/gitbase:$(VERSION) && \
+	mkdir -p build/$${PACKAGE_NAME} && \
+	docker cp gitbase-temp:/bin/gitbase build/$${PACKAGE_NAME} && \
+	cd build && \
+	tar czvf $${PACKAGE_NAME}.tar.gz $${PACKAGE_NAME} && \
+	docker rm gitbase-temp

--- a/docs/using-gitbase/getting-started.md
+++ b/docs/using-gitbase/getting-started.md
@@ -43,6 +43,8 @@ go get -u github.com/src-d/gitbase/...
 
 #### Oniguruma support
 
+**Note:** Oniguruma is enabled in the docker container and "static" linux binary.
+
 On linux and macOS you can choose to build gitbase with oniguruma support, resulting in faster results for queries using the `language` UDF.
 
 macOS:


### PR DESCRIPTION
Now the docker container is based on alpine to make it slimmer. It also
generates a new linux binary with libxml2 and oniguruma statically
linked. This build uses musl instead of glibc.

It also generates a linux static package extracted from the docker
image.