### PR TITLE
build: only tag latest in docker when version is not prerelease

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ jobs:
 
       before_deploy:
         - make packages
-        - DOCKER_PUSH_LATEST=1 make docker-push
+        - export DOCKER_PUSH_LATEST=$(echo ${TRAVIS_BRANCH} | grep -E '^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$') || true
+        - make docker-push
         - make static-package
 
       deploy:


### PR DESCRIPTION
Version tag has to match `v0.1.2`

