### PR TITLE
function: log bblfsh errors on UAST instead of returning them

### DIFF
--- a/internal/function/uast_test.go
+++ b/internal/function/uast_test.go
@@ -238,7 +238,7 @@ func TestUASTChildren(t *testing.T) {
 		{
 			mode:     "semantic",
 			key:      uast.KeyType,
-			expected: []string{"uast:FunctionGroup", "Expr"},
+			expected: []string{"uast:FunctionGroup", "python:Expr"},
 		},
 		{
 			mode:     "annotated",

--- a/internal/function/uast_utils.go
+++ b/internal/function/uast_utils.go
@@ -140,8 +140,8 @@ func marshalNodes(arr nodes.Array) (interface{}, error) {
 		return nil, nil
 	}
 
-	buf := &bytes.Buffer{}
-	if err := nodesproto.WriteTo(buf, arr); err != nil {
+	var buf bytes.Buffer
+	if err := nodesproto.WriteTo(&buf, arr); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #444 

I have been trying for a while but I can't seem to reproduce the original error (which is normal, considering it's a bblfsh error and there be dragons).

Anyway, as said in the issue, the UDF should not fail, so now all errors are logged but not returned and nil is returned instead.