### PR TITLE
Update Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
 RUN apt-get update \
-  && apt-get -y install libxml2 git \
+  && apt-get -y --no-install-recommends install libxml2 git \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Adds `--no-install-recommends` to reduce docker image size by 18mb. 