### PR TITLE
server: make gitbase the current database

### DIFF
--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -206,8 +206,9 @@ func (c *Server) buildDatabase() error {
 		return err
 	}
 
-	c.engine.AddDatabase(sql.NewInformationSchemaDatabase(c.engine.Catalog))
 	c.engine.AddDatabase(gitbase.NewDatabase(c.Name))
+	c.engine.AddDatabase(sql.NewInformationSchemaDatabase(c.engine.Catalog))
+	c.engine.Catalog.SetCurrentDatabase(c.Name)
 	logrus.WithField("db", c.Name).Debug("registered database to catalog")
 
 	c.engine.Catalog.RegisterFunctions(function.Functions)


### PR DESCRIPTION
This makes queries work again. It was using `information_schema` as the current database. It uses the first one added if not specified.