### PR TITLE
Server follow symlinks when passed as an argument

### DIFF
--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -273,6 +273,17 @@ func (c *Server) addMatch(match string) error {
 		return err
 	}
 
+	rooti, err := os.Lstat(root)
+	if err != nil {
+		return err
+	}
+	if rooti.Mode()&os.ModeSymlink != 0 {
+		root, err = os.Readlink(root)
+		if err != nil {
+			return err
+		}
+	}
+
 	initDepth := strings.Count(root, string(os.PathSeparator))
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -278,8 +278,7 @@ func (c *Server) addMatch(match string) error {
 		return err
 	}
 	if rooti.Mode()&os.ModeSymlink != 0 {
-		root, err = os.Readlink(root)
-		if err != nil {
+		if root, err = os.Readlink(root); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR tries to close issue #547. The server should follow symlinks passed as an argument. For example, if I have a directory `~/Desktop/repos` and a softlink `~/Desktop/repos-link -> ~/Desktop/repos`, running

```
$ go run main.go server -d ~/Desktop/repos/
```

and 

```
go run main.go server -d ~/Desktop/repos-link/
```

should behave the same.