### PR TITLE
gitbase: show pushed down properties to tables in explain

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -50,8 +50,14 @@ var _ Squashable = (*blobsTable)(nil)
 func (blobsTable) isSquashable()   {}
 func (blobsTable) isGitbaseTable() {}
 
-func (blobsTable) String() string {
-	return printTable(BlobsTableName, BlobsSchema)
+func (r blobsTable) String() string {
+	return printTable(
+		BlobsTableName,
+		BlobsSchema,
+		r.projection,
+		r.filters,
+		r.index,
+	)
 }
 
 func (blobsTable) Name() string {

--- a/commit_blobs.go
+++ b/commit_blobs.go
@@ -33,8 +33,14 @@ var _ Squashable = (*blobsTable)(nil)
 func (commitBlobsTable) isSquashable()   {}
 func (commitBlobsTable) isGitbaseTable() {}
 
-func (commitBlobsTable) String() string {
-	return printTable(CommitBlobsTableName, CommitBlobsSchema)
+func (t commitBlobsTable) String() string {
+	return printTable(
+		CommitBlobsTableName,
+		CommitBlobsSchema,
+		nil,
+		t.filters,
+		t.index,
+	)
 }
 
 func (commitBlobsTable) Name() string { return CommitBlobsTableName }

--- a/commit_files.go
+++ b/commit_files.go
@@ -38,8 +38,14 @@ var _ Squashable = (*commitFilesTable)(nil)
 func (commitFilesTable) isSquashable()   {}
 func (commitFilesTable) isGitbaseTable() {}
 
-func (commitFilesTable) String() string {
-	return printTable(CommitFilesTableName, CommitFilesSchema)
+func (t commitFilesTable) String() string {
+	return printTable(
+		CommitFilesTableName,
+		CommitFilesSchema,
+		nil,
+		t.filters,
+		t.index,
+	)
 }
 
 func (commitFilesTable) Name() string { return CommitFilesTableName }

--- a/commit_trees.go
+++ b/commit_trees.go
@@ -34,8 +34,14 @@ var _ Squashable = (*commitTreesTable)(nil)
 func (commitTreesTable) isSquashable()   {}
 func (commitTreesTable) isGitbaseTable() {}
 
-func (commitTreesTable) String() string {
-	return printTable(CommitTreesTableName, CommitTreesSchema)
+func (t commitTreesTable) String() string {
+	return printTable(
+		CommitTreesTableName,
+		CommitTreesSchema,
+		nil,
+		t.filters,
+		t.index,
+	)
 }
 
 func (commitTreesTable) Name() string { return CommitTreesTableName }

--- a/commits.go
+++ b/commits.go
@@ -40,8 +40,14 @@ var _ Squashable = (*commitsTable)(nil)
 func (commitsTable) isSquashable()   {}
 func (commitsTable) isGitbaseTable() {}
 
-func (commitsTable) String() string {
-	return printTable(CommitsTableName, CommitsSchema)
+func (r commitsTable) String() string {
+	return printTable(
+		CommitsTableName,
+		CommitsSchema,
+		nil,
+		r.filters,
+		r.index,
+	)
 }
 
 func (commitsTable) Name() string {

--- a/files.go
+++ b/files.go
@@ -149,8 +149,14 @@ func (filesTable) handledColumns() []string {
 	return []string{"repository_id", "tree_hash", "blob_hash", "file_path"}
 }
 
-func (filesTable) String() string {
-	return printTable(FilesTableName, FilesSchema)
+func (r filesTable) String() string {
+	return printTable(
+		FilesTableName,
+		FilesSchema,
+		r.projection,
+		r.filters,
+		r.index,
+	)
 }
 
 // IndexKeyValues implements the sql.IndexableTable interface.

--- a/ref_commits.go
+++ b/ref_commits.go
@@ -37,8 +37,14 @@ var _ Squashable = (*refCommitsTable)(nil)
 func (refCommitsTable) isSquashable()   {}
 func (refCommitsTable) isGitbaseTable() {}
 
-func (refCommitsTable) String() string {
-	return printTable(RefCommitsTableName, RefCommitsSchema)
+func (t refCommitsTable) String() string {
+	return printTable(
+		RefCommitsTableName,
+		RefCommitsSchema,
+		nil,
+		t.filters,
+		t.index,
+	)
 }
 
 func (refCommitsTable) Name() string { return RefCommitsTableName }

--- a/references.go
+++ b/references.go
@@ -36,7 +36,13 @@ func (referencesTable) isSquashable()   {}
 func (referencesTable) isGitbaseTable() {}
 
 func (r referencesTable) String() string {
-	return printTable(ReferencesTableName, RefsSchema)
+	return printTable(
+		ReferencesTableName,
+		RefsSchema,
+		nil,
+		r.filters,
+		r.index,
+	)
 }
 
 func (referencesTable) Name() string {

--- a/remotes.go
+++ b/remotes.go
@@ -44,7 +44,13 @@ func (remotesTable) Schema() sql.Schema {
 }
 
 func (r remotesTable) String() string {
-	return printTable(RemotesTableName, RemotesSchema)
+	return printTable(
+		RemotesTableName,
+		RemotesSchema,
+		nil,
+		r.filters,
+		r.index,
+	)
 }
 
 func (r *remotesTable) WithFilters(filters []sql.Expression) sql.Table {

--- a/repositories.go
+++ b/repositories.go
@@ -36,7 +36,13 @@ func (repositoriesTable) Schema() sql.Schema {
 }
 
 func (r repositoriesTable) String() string {
-	return printTable(RepositoriesTableName, RepositoriesSchema)
+	return printTable(
+		RepositoriesTableName,
+		RepositoriesSchema,
+		nil,
+		r.filters,
+		r.index,
+	)
 }
 
 func (repositoriesTable) HandledFilters(filters []sql.Expression) []sql.Expression {

--- a/table.go
+++ b/table.go
@@ -22,18 +22,62 @@ type gitBase interface {
 	isGitbaseTable()
 }
 
-func printTable(name string, tableSchema sql.Schema) string {
+func printTable(
+	name string,
+	tableSchema sql.Schema,
+	projection []string,
+	filters []sql.Expression,
+	index sql.IndexLookup,
+) string {
 	p := sql.NewTreePrinter()
 	_ = p.WriteNode("Table(%s)", name)
-	var schema = make([]string, len(tableSchema))
+	var children = make([]string, len(tableSchema))
 	for i, col := range tableSchema {
-		schema[i] = fmt.Sprintf(
+		children[i] = fmt.Sprintf(
 			"Column(%s, %s, nullable=%v)",
 			col.Name,
 			col.Type.Type().String(),
 			col.Nullable,
 		)
 	}
-	_ = p.WriteChildren(schema...)
+
+	if len(projection) > 0 {
+		children = append(children, printableProjection(projection))
+	}
+
+	if len(filters) > 0 {
+		children = append(children, printableFilters(filters))
+	}
+
+	if index != nil {
+		children = append(children, printableIndexes(index))
+	}
+
+	_ = p.WriteChildren(children...)
+	return p.String()
+}
+
+func printableFilters(filters []sql.Expression) string {
+	p := sql.NewTreePrinter()
+	_ = p.WriteNode("Filters")
+	var fs = make([]string, len(filters))
+	for i, f := range filters {
+		fs[i] = f.String()
+	}
+	_ = p.WriteChildren(fs...)
+	return p.String()
+}
+
+func printableProjection(projection []string) string {
+	p := sql.NewTreePrinter()
+	_ = p.WriteNode("Projected")
+	_ = p.WriteChildren(projection...)
+	return p.String()
+}
+
+func printableIndexes(idx sql.IndexLookup) string {
+	p := sql.NewTreePrinter()
+	_ = p.WriteNode("Indexes")
+	_ = p.WriteChildren(idx.Indexes()...)
 	return p.String()
 }

--- a/table_test.go
+++ b/table_test.go
@@ -15,8 +15,8 @@ const expectedString = `Table(foo)
 func TestTableString(t *testing.T) {
 	require := require.New(t)
 	schema := sql.Schema{
-		{"col1", sql.Text, nil, true, ""},
-		{"col2", sql.Int64, nil, false, ""},
+		{Name: "col1", Type: sql.Text, Nullable: true},
+		{Name: "col2", Type: sql.Int64},
 	}
-	require.Equal(expectedString, printTable("foo", schema))
+	require.Equal(expectedString, printTable("foo", schema, nil, nil, nil))
 }

--- a/tree_entries.go
+++ b/tree_entries.go
@@ -122,7 +122,13 @@ func (treeEntriesTable) handledColumns() []string {
 }
 
 func (r treeEntriesTable) String() string {
-	return printTable(TreeEntriesTableName, TreeEntriesSchema)
+	return printTable(
+		TreeEntriesTableName,
+		TreeEntriesSchema,
+		nil,
+		r.filters,
+		r.index,
+	)
 }
 
 // IndexKeyValues implements the sql.IndexableTable interface.


### PR DESCRIPTION
Fixes #647 

Turns out it was just implemented for squashed tables