### PR TITLE
gitbase: implement table checksums

### DIFF
--- a/blobs_test.go
+++ b/blobs_test.go
@@ -13,7 +13,7 @@ func TestBlobsTable(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := getTable(require, BlobsTableName)
+	table := getTable(t, BlobsTableName, ctx)
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)
@@ -28,7 +28,7 @@ func TestBlobsTable(t *testing.T) {
 
 func TestBlobsLimit(t *testing.T) {
 	require := require.New(t)
-	session, _, cleanup := setup(t)
+	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
 	prev := blobsMaxSize
@@ -37,8 +37,9 @@ func TestBlobsLimit(t *testing.T) {
 		blobsMaxSize = prev
 	}()
 
-	table := newBlobsTable().WithProjection([]string{"blob_content"})
-	rows, err := tableToRows(session, table)
+	table := newBlobsTable(poolFromCtx(t, ctx)).
+		WithProjection([]string{"blob_content"})
+	rows, err := tableToRows(ctx, table)
 	require.NoError(err)
 
 	expected := []struct {
@@ -72,7 +73,7 @@ func TestBlobsPushdown(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newBlobsTable()
+	table := newBlobsTable(poolFromCtx(t, ctx))
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)

--- a/checksum.go
+++ b/checksum.go
@@ -1,0 +1,116 @@
+package gitbase
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/base64"
+	"io"
+
+	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+type checksumable struct {
+	pool *RepositoryPool
+}
+
+func (c *checksumable) Checksum() (string, error) {
+	hash := sha1.New()
+	for _, id := range c.pool.idOrder {
+		repo := c.pool.repositories[id]
+		hash.Write([]byte(id))
+
+		bytes, err := readChecksum(repo)
+		if err != nil {
+			return "", err
+		}
+
+		if _, err = hash.Write(bytes); err != nil {
+			return "", err
+		}
+
+		bytes, err = readRefs(repo)
+		if err != nil {
+			return "", err
+		}
+
+		if _, err = hash.Write(bytes); err != nil {
+			return "", err
+		}
+	}
+
+	return base64.StdEncoding.EncodeToString(hash.Sum(nil)), nil
+}
+
+func readChecksum(r repository) ([]byte, error) {
+	fs, err := r.FS()
+	if err != nil {
+		return nil, err
+	}
+
+	dot, packfiles, err := repositoryPackfiles(fs)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []byte
+	for _, p := range packfiles {
+		f, err := dot.ObjectPack(p)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err = f.Seek(-20, io.SeekEnd); err != nil {
+			return nil, err
+		}
+
+		var checksum = make([]byte, 20)
+		if _, err = io.ReadFull(f, checksum); err != nil {
+			return nil, err
+		}
+
+		if err = f.Close(); err != nil {
+			return nil, err
+		}
+
+		result = append(result, checksum...)
+	}
+
+	return result, nil
+}
+
+func readRefs(r repository) ([]byte, error) {
+	repo, err := r.Repo()
+	if err != nil {
+		if err == git.ErrRepositoryNotExists {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(nil)
+
+	head, err := repo.Head()
+	if err != nil && err != plumbing.ErrReferenceNotFound {
+		return nil, err
+	} else {
+		buf.WriteString("HEAD")
+		buf.WriteString(head.Hash().String())
+	}
+
+	refs, err := repo.References()
+	if err != nil {
+		return nil, err
+	}
+
+	err = refs.ForEach(func(r *plumbing.Reference) error {
+		buf.WriteString(string(r.Name()))
+		buf.WriteString(r.Hash().String())
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,40 @@
+package gitbase
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
+)
+
+func TestChecksum(t *testing.T) {
+	require := require.New(t)
+
+	require.NoError(fixtures.Init())
+	defer func() {
+		require.NoError(fixtures.Clean())
+	}()
+
+	pool := NewRepositoryPool(cache.DefaultMaxSize)
+
+	for i, f := range fixtures.ByTag("worktree") {
+		path := f.Worktree().Root()
+		require.NoError(pool.AddGitWithID(fmt.Sprintf("repo_%d", i), path))
+	}
+
+	c := &checksumable{pool}
+	checksum, err := c.Checksum()
+	require.NoError(err)
+	require.Equal("ogfv7HAwFigDgtuW4tbnEP+Zl40=", checksum)
+
+	pool = NewRepositoryPool(cache.DefaultMaxSize)
+	path := fixtures.ByTag("worktree").One().Worktree().Root()
+	require.NoError(pool.AddGitWithID("worktree", path))
+
+	c = &checksumable{pool}
+	checksum, err = c.Checksum()
+	require.NoError(err)
+	require.Equal("5kfLCygyBSZFMh+nFzFNk3zAUTQ=", checksum)
+}

--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -204,7 +204,7 @@ func (c *Server) buildDatabase() error {
 		return err
 	}
 
-	c.engine.AddDatabase(gitbase.NewDatabase(c.Name))
+	c.engine.AddDatabase(gitbase.NewDatabase(c.Name, c.pool))
 	c.engine.AddDatabase(sql.NewInformationSchemaDatabase(c.engine.Catalog))
 	c.engine.Catalog.SetCurrentDatabase(c.Name)
 	logrus.WithField("db", c.Name).Debug("registered database to catalog")

--- a/commit_blobs_test.go
+++ b/commit_blobs_test.go
@@ -14,11 +14,11 @@ import (
 func TestCommitBlobsTableRowIter(t *testing.T) {
 	require := require.New(t)
 
-	table := newCommitBlobsTable()
-	require.NotNil(table)
-
 	ctx, paths, cleanup := setupRepos(t)
 	defer cleanup()
+
+	table := newCommitBlobsTable(poolFromCtx(t, ctx))
+	require.NotNil(table)
 
 	expectedRows := []sql.Row{
 		sql.NewRow(paths[0], "e8d3ffab552895c19b9fcf7aa264d277cde33881", "32858aad3c383ed1ff0a0f9bdf231d54a00c9e88"),

--- a/commit_files_test.go
+++ b/commit_files_test.go
@@ -13,11 +13,11 @@ import (
 func TestCommitFilesTableRowIter(t *testing.T) {
 	require := require.New(t)
 
-	table := newCommitFilesTable()
-	require.NotNil(table)
-
 	ctx, _, cleanup := setupRepos(t)
 	defer cleanup()
+
+	table := newCommitFilesTable(poolFromCtx(t, ctx))
+	require.NotNil(table)
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)

--- a/commit_trees.go
+++ b/commit_trees.go
@@ -12,6 +12,7 @@ import (
 )
 
 type commitTreesTable struct {
+	checksumable
 	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
@@ -24,8 +25,8 @@ var CommitTreesSchema = sql.Schema{
 	{Name: "tree_hash", Type: sql.Text, Source: CommitTreesTableName},
 }
 
-func newCommitTreesTable() Indexable {
-	return new(commitTreesTable)
+func newCommitTreesTable(pool *RepositoryPool) Indexable {
+	return &commitTreesTable{checksumable: checksumable{pool}}
 }
 
 var _ Table = (*commitTreesTable)(nil)
@@ -110,13 +111,13 @@ func (t *commitTreesTable) PartitionRows(
 }
 
 // IndexKeyValues implements the sql.IndexableTable interface.
-func (*commitTreesTable) IndexKeyValues(
+func (t *commitTreesTable) IndexKeyValues(
 	ctx *sql.Context,
 	colNames []string,
 ) (sql.PartitionIndexKeyValueIter, error) {
 	return newTablePartitionIndexKeyValueIter(
 		ctx,
-		newCommitTreesTable(),
+		newCommitTreesTable(t.pool),
 		CommitTreesTableName,
 		colNames,
 		new(commitTreesRowKeyMapper),

--- a/commits_test.go
+++ b/commits_test.go
@@ -13,7 +13,7 @@ func TestCommitsTable(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newCommitsTable()
+	table := newCommitsTable(poolFromCtx(t, ctx))
 	rows, err := tableToRows(ctx, table)
 	require.Nil(err)
 	require.Len(rows, 9)
@@ -30,7 +30,7 @@ func TestCommitsPushdown(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newCommitsTable()
+	table := newCommitsTable(poolFromCtx(t, ctx))
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)
@@ -89,7 +89,7 @@ func TestCommitsParents(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newCommitsTable()
+	table := newCommitsTable(poolFromCtx(t, ctx))
 	rows, err := tableToRows(ctx, table)
 	require.NoError(t, err)
 	require.Len(t, rows, 9)

--- a/common_test.go
+++ b/common_test.go
@@ -253,3 +253,12 @@ func testTableIterClosed(t *testing.T, table sql.IndexableTable) {
 
 	require.True(closed.Check())
 }
+
+func poolFromCtx(t *testing.T, ctx *sql.Context) *RepositoryPool {
+	t.Helper()
+
+	session, err := getSession(ctx)
+	require.NoError(t, err)
+
+	return session.Pool
+}

--- a/database.go
+++ b/database.go
@@ -47,20 +47,20 @@ type Database struct {
 
 // NewDatabase creates a new Database structure and initializes its
 // tables with the given pool
-func NewDatabase(name string) sql.Database {
+func NewDatabase(name string, pool *RepositoryPool) sql.Database {
 	return &Database{
 		name:         name,
-		commits:      newCommitsTable(),
-		references:   newReferencesTable(),
-		blobs:        newBlobsTable(),
-		treeEntries:  newTreeEntriesTable(),
-		repositories: newRepositoriesTable(),
-		remotes:      newRemotesTable(),
-		refCommits:   newRefCommitsTable(),
-		commitTrees:  newCommitTreesTable(),
-		commitBlobs:  newCommitBlobsTable(),
-		commitFiles:  newCommitFilesTable(),
-		files:        newFilesTable(),
+		commits:      newCommitsTable(pool),
+		references:   newReferencesTable(pool),
+		blobs:        newBlobsTable(pool),
+		treeEntries:  newTreeEntriesTable(pool),
+		repositories: newRepositoriesTable(pool),
+		remotes:      newRemotesTable(pool),
+		refCommits:   newRefCommitsTable(pool),
+		commitTrees:  newCommitTreesTable(pool),
+		commitBlobs:  newCommitBlobsTable(pool),
+		commitFiles:  newCommitFilesTable(pool),
+		files:        newFilesTable(pool),
 	}
 }
 

--- a/database_test.go
+++ b/database_test.go
@@ -19,7 +19,7 @@ const testDBName = "foo"
 func TestDatabase_Tables(t *testing.T) {
 	require := require.New(t)
 
-	db := getDB(require, testDBName)
+	db := getDB(t, testDBName, NewRepositoryPool(0))
 
 	tables := db.Tables()
 	var tableNames []string
@@ -49,19 +49,22 @@ func TestDatabase_Tables(t *testing.T) {
 func TestDatabase_Name(t *testing.T) {
 	require := require.New(t)
 
-	db := getDB(require, testDBName)
+	db := getDB(t, testDBName, NewRepositoryPool(0))
 	require.Equal(testDBName, db.Name())
 }
 
-func getDB(require *require.Assertions, name string) sql.Database {
-	db := NewDatabase(name)
-	require.NotNil(db)
+func getDB(t *testing.T, name string, pool *RepositoryPool) sql.Database {
+	t.Helper()
+	db := NewDatabase(name, pool)
+	require.NotNil(t, db)
 
 	return db
 }
 
-func getTable(require *require.Assertions, name string) sql.Table {
-	db := getDB(require, "foo")
+func getTable(t *testing.T, name string, ctx *sql.Context) sql.Table {
+	t.Helper()
+	require := require.New(t)
+	db := getDB(t, "foo", poolFromCtx(t, ctx))
 	require.NotNil(db)
 	require.Equal(db.Name(), "foo")
 

--- a/files.go
+++ b/files.go
@@ -11,6 +11,7 @@ import (
 )
 
 type filesTable struct {
+	checksumable
 	partitioned
 	filters    []sql.Expression
 	projection []string
@@ -28,8 +29,8 @@ var FilesSchema = sql.Schema{
 	{Name: "blob_size", Type: sql.Int64, Source: "files"},
 }
 
-func newFilesTable() *filesTable {
-	return new(filesTable)
+func newFilesTable(pool *RepositoryPool) *filesTable {
+	return &filesTable{checksumable: checksumable{pool}}
 }
 
 var _ Table = (*filesTable)(nil)
@@ -160,13 +161,13 @@ func (r filesTable) String() string {
 }
 
 // IndexKeyValues implements the sql.IndexableTable interface.
-func (*filesTable) IndexKeyValues(
+func (r *filesTable) IndexKeyValues(
 	ctx *sql.Context,
 	colNames []string,
 ) (sql.PartitionIndexKeyValueIter, error) {
 	return newPartitionedIndexKeyValueIter(
 		ctx,
-		newFilesTable(),
+		newFilesTable(r.pool),
 		colNames,
 		newFilesKeyValueIter,
 	)

--- a/fs_error_test.go
+++ b/fs_error_test.go
@@ -107,7 +107,7 @@ func testTable(t *testing.T, tableName string, number int) {
 	ctx, cleanup := setupErrorRepos(t)
 	defer cleanup()
 
-	table := getTable(require, tableName)
+	table := getTable(t, tableName, ctx)
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	engine := newBaseEngine()
 	require.NoError(t, fixtures.Init())
 	defer func() {
 		require.NoError(t, fixtures.Clean())
@@ -37,6 +36,8 @@ func TestIntegration(t *testing.T) {
 
 	pool := gitbase.NewRepositoryPool(cache.DefaultMaxSize)
 	require.NoError(t, pool.AddGitWithID("worktree", path))
+
+	engine := newBaseEngine(pool)
 
 	testCases := []struct {
 		query  string
@@ -351,7 +352,7 @@ func TestSquashCorrectness(t *testing.T) {
 	engine, pool, cleanup := setup(t)
 	defer cleanup()
 
-	squashEngine := newSquashEngine()
+	squashEngine := newSquashEngine(pool)
 
 	queries := []string{
 		`SELECT * FROM repositories`,
@@ -501,7 +502,7 @@ func TestMissingHeadRefs(t *testing.T) {
 		}),
 	)
 
-	engine := newBaseEngine()
+	engine := newBaseEngine(pool)
 
 	session := gitbase.NewSession(pool)
 	ctx := sql.NewContext(context.TODO(), sql.WithSession(session))
@@ -618,9 +619,9 @@ func BenchmarkQueries(b *testing.B) {
 		sql.WithSession(gitbase.NewSession(pool)),
 	)
 
-	engine := newBaseEngine()
-	squashEngine := newSquashEngine()
-	squashIndexEngine := newSquashEngine()
+	engine := newBaseEngine(pool)
+	squashEngine := newSquashEngine(pool)
+	squashIndexEngine := newSquashEngine(pool)
 
 	tmpDir2, err := ioutil.TempDir(os.TempDir(), "pilosa-idx-gitbase")
 	require.NoError(b, err)
@@ -679,8 +680,8 @@ func TestIndexes(t *testing.T) {
 		sql.WithSession(gitbase.NewSession(pool)),
 	)
 
-	baseEngine := newBaseEngine()
-	squashEngine := newSquashEngine()
+	baseEngine := newBaseEngine(pool)
+	squashEngine := newSquashEngine(pool)
 
 	tmpDir2, err := ioutil.TempDir(os.TempDir(), "pilosa-idx-gitbase")
 	require.NoError(t, err)
@@ -878,11 +879,11 @@ func setup(t testing.TB) (*sqle.Engine, *gitbase.RepositoryPool, func()) {
 		pool.AddGitWithID("worktree", f.Worktree().Root())
 	}
 
-	return newBaseEngine(), pool, cleanup
+	return newBaseEngine(pool), pool, cleanup
 }
 
-func newSquashEngine() *sqle.Engine {
-	engine := newBaseEngine()
+func newSquashEngine(pool *gitbase.RepositoryPool) *sqle.Engine {
+	engine := newBaseEngine(pool)
 
 	engine.Catalog.RegisterFunctions(sqlfunction.Defaults)
 	engine.Analyzer = analyzer.NewBuilder(engine.Catalog).
@@ -892,8 +893,8 @@ func newSquashEngine() *sqle.Engine {
 	return engine
 }
 
-func newBaseEngine() *sqle.Engine {
-	foo := gitbase.NewDatabase("foo")
+func newBaseEngine(pool *gitbase.RepositoryPool) *sqle.Engine {
+	foo := gitbase.NewDatabase("foo", pool)
 	au := new(auth.None)
 	engine := command.NewDatabaseEngine(au, "test", 0, false)
 

--- a/internal/rule/squashjoins_test.go
+++ b/internal/rule/squashjoins_test.go
@@ -18,7 +18,9 @@ func TestAnalyzeSquashJoinsExchange(t *testing.T) {
 	require := require.New(t)
 
 	catalog := sql.NewCatalog()
-	catalog.AddDatabase(gitbase.NewDatabase("foo"))
+	catalog.AddDatabase(
+		gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(0)),
+	)
 	a := analyzer.NewBuilder(catalog).
 		WithParallelism(2).
 		AddPostAnalyzeRule(SquashJoinsRule, SquashJoins).
@@ -50,7 +52,9 @@ func TestAnalyzeSquashNaturalJoins(t *testing.T) {
 	require := require.New(t)
 
 	catalog := sql.NewCatalog()
-	catalog.AddDatabase(gitbase.NewDatabase("foo"))
+	catalog.AddDatabase(
+		gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(0)),
+	)
 	a := analyzer.NewBuilder(catalog).
 		WithParallelism(2).
 		AddPostAnalyzeRule(SquashJoinsRule, SquashJoins).
@@ -87,7 +91,7 @@ func TestAnalyzeSquashNaturalJoins(t *testing.T) {
 func TestSquashJoins(t *testing.T) {
 	require := require.New(t)
 
-	tables := gitbase.NewDatabase("").Tables()
+	tables := gitbaseTables()
 
 	node := plan.NewProject(
 		[]sql.Expression{lit(1)},
@@ -184,7 +188,7 @@ func TestSquashJoins(t *testing.T) {
 func TestSquashJoinsIndexes(t *testing.T) {
 	require := require.New(t)
 
-	tables := gitbase.NewDatabase("").Tables()
+	tables := gitbaseTables()
 
 	idx1, idx2 := &dummyLookup{1}, &dummyLookup{2}
 
@@ -235,7 +239,7 @@ func TestSquashJoinsIndexes(t *testing.T) {
 func TestSquashJoinsUnsquashable(t *testing.T) {
 	require := require.New(t)
 
-	tables := gitbase.NewDatabase("").Tables()
+	tables := gitbaseTables()
 
 	node := plan.NewProject(
 		[]sql.Expression{lit(1)},
@@ -258,7 +262,7 @@ func TestSquashJoinsUnsquashable(t *testing.T) {
 func TestSquashJoinsPartial(t *testing.T) {
 	require := require.New(t)
 
-	tables := gitbase.NewDatabase("").Tables()
+	tables := gitbaseTables()
 
 	node := plan.NewProject(
 		[]sql.Expression{lit(1)},
@@ -323,7 +327,7 @@ func TestSquashJoinsPartial(t *testing.T) {
 func TestSquashJoinsSchema(t *testing.T) {
 	require := require.New(t)
 
-	tables := gitbase.NewDatabase("").Tables()
+	tables := gitbaseTables()
 
 	node := plan.NewInnerJoin(
 		plan.NewResolvedTable(
@@ -366,7 +370,7 @@ func TestSquashJoinsSchema(t *testing.T) {
 }
 
 func TestBuildSquashedTable(t *testing.T) {
-	tables := gitbase.NewDatabase("").Tables()
+	tables := gitbaseTables()
 	repositories := tables[gitbase.RepositoriesTableName]
 	refs := tables[gitbase.ReferencesTableName]
 	refCommits := tables[gitbase.RefCommitsTableName]
@@ -2143,7 +2147,7 @@ func fixIdx(t *testing.T, e sql.Expression, schema sql.Schema) sql.Expression {
 }
 
 func TestIsJoinLeafSquashable(t *testing.T) {
-	tables := gitbase.NewDatabase("").Tables()
+	tables := gitbaseTables()
 	t1 := plan.NewResolvedTable(
 		tables[gitbase.RepositoriesTableName],
 	)
@@ -2230,7 +2234,7 @@ func TestIsJoinLeafSquashable(t *testing.T) {
 }
 
 func TestOrderedTableNames(t *testing.T) {
-	tables := gitbase.NewDatabase("foo").Tables()
+	tables := gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(0)).Tables()
 
 	input := []sql.Table{
 		tables[gitbase.BlobsTableName],
@@ -2391,7 +2395,7 @@ func TestRemoveRedundantCompoundFilters(t *testing.T) {
 
 func TestIsJoinCondSquashable(t *testing.T) {
 	require := require.New(t)
-	tables := gitbase.NewDatabase("").Tables()
+	tables := gitbaseTables()
 	repos := plan.NewResolvedTable(
 		tables[gitbase.ReferencesTableName],
 	)
@@ -2776,4 +2780,8 @@ func (dummyLookup) Values(p sql.Partition) (sql.IndexValueIter, error) {
 
 func (l dummyLookup) Indexes() []string {
 	return []string{fmt.Sprintf("index_%d", l.n)}
+}
+
+func gitbaseTables() map[string]sql.Table {
+	return gitbase.NewDatabase("", gitbase.NewRepositoryPool(0)).Tables()
 }

--- a/ref_commits_test.go
+++ b/ref_commits_test.go
@@ -14,7 +14,7 @@ func TestRefCommitsRowIter(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	rows, err := tableToRows(ctx, newRefCommitsTable())
+	rows, err := tableToRows(ctx, newRefCommitsTable(poolFromCtx(t, ctx)))
 	require.NoError(err)
 
 	for i, row := range rows {

--- a/references_test.go
+++ b/references_test.go
@@ -14,7 +14,7 @@ func TestReferencesTable(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newReferencesTable()
+	table := newReferencesTable(poolFromCtx(t, ctx))
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)
 
@@ -37,7 +37,7 @@ func TestReferencesPushdown(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newReferencesTable()
+	table := newReferencesTable(poolFromCtx(t, ctx))
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)
@@ -83,10 +83,11 @@ func TestReferencesIndexKeyValueIter(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	iter, err := newReferencesTable().IndexKeyValues(ctx, []string{"ref_name"})
+	iter, err := newReferencesTable(poolFromCtx(t, ctx)).
+		IndexKeyValues(ctx, []string{"ref_name"})
 	require.NoError(err)
 
-	rows, err := tableToRows(ctx, newReferencesTable())
+	rows, err := tableToRows(ctx, newReferencesTable(poolFromCtx(t, ctx)))
 	require.NoError(err)
 
 	var expected []keyValue

--- a/remotes_test.go
+++ b/remotes_test.go
@@ -16,7 +16,7 @@ func TestRemotesTable(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newRemotesTable()
+	table := newRemotesTable(poolFromCtx(t, ctx))
 
 	session := ctx.Session.(*Session)
 	pool := session.Pool
@@ -70,7 +70,7 @@ func TestRemotesPushdown(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newRemotesTable()
+	table := newRemotesTable(poolFromCtx(t, ctx))
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -27,7 +27,7 @@ func TestRepositoriesTable(t *testing.T) {
 	session := NewSession(pool)
 	ctx := sql.NewContext(context.TODO(), sql.WithSession(session))
 
-	db := NewDatabase(RepositoriesTableName)
+	db := NewDatabase(RepositoriesTableName, poolFromCtx(t, ctx))
 	require.NotNil(db)
 
 	tables := db.Tables()
@@ -58,7 +58,7 @@ func TestRepositoriesPushdown(t *testing.T) {
 	ctx, path, cleanup := setup(t)
 	defer cleanup()
 
-	table := newRepositoriesTable()
+	table := newRepositoriesTable(poolFromCtx(t, ctx))
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)

--- a/squash_iterator_test.go
+++ b/squash_iterator_test.go
@@ -135,7 +135,7 @@ func TestAllRefsIter(t *testing.T) {
 
 	expectedRowsLen := len(rows)
 
-	table := newReferencesTable()
+	table := newReferencesTable(poolFromCtx(t, ctx))
 	expected, err := tableToRows(ctx, table)
 	require.NoError(err)
 
@@ -317,7 +317,10 @@ func TestAllCommitsIter(t *testing.T) {
 
 	expectedRowsLen := len(rows)
 
-	expected, err := tableToRows(ctx, newCommitsTable())
+	expected, err := tableToRows(
+		ctx,
+		newCommitsTable(poolFromCtx(t, ctx)),
+	)
 	require.NoError(err)
 
 	require.ElementsMatch(expected, rows)
@@ -404,7 +407,7 @@ func TestRefHEADCommitsIter(t *testing.T) {
 
 	expectedRowsLen := len(rows)
 
-	table := newReferencesTable()
+	table := newReferencesTable(poolFromCtx(t, ctx))
 	expected, err := tableToRows(ctx, table)
 	require.NoError(err)
 
@@ -461,7 +464,7 @@ func TestAllTreeEntriesIter(t *testing.T) {
 
 	expectedRowsLen := len(rows)
 
-	expected, err := tableToRows(ctx, newTreeEntriesTable())
+	expected, err := tableToRows(ctx, newTreeEntriesTable(poolFromCtx(t, ctx)))
 	require.NoError(err)
 
 	require.ElementsMatch(expected, rows)
@@ -653,7 +656,10 @@ func TestRepoBlobsIter(t *testing.T) {
 		),
 	)
 
-	expected, err := tableToRows(ctx, newBlobsTable())
+	expected, err := tableToRows(
+		ctx,
+		newBlobsTable(poolFromCtx(t, ctx)),
+	)
 	require.NoError(err)
 
 	for i := range rows {

--- a/table.go
+++ b/table.go
@@ -9,6 +9,7 @@ import (
 // Table represents a gitbase table.
 type Table interface {
 	sql.FilteredTable
+	sql.Checksumable
 	sql.PartitionCounter
 	gitBase
 }

--- a/tree_entries.go
+++ b/tree_entries.go
@@ -12,6 +12,7 @@ import (
 )
 
 type treeEntriesTable struct {
+	checksumable
 	partitioned
 	filters []sql.Expression
 	index   sql.IndexLookup
@@ -26,8 +27,8 @@ var TreeEntriesSchema = sql.Schema{
 	{Name: "tree_entry_mode", Type: sql.Text, Nullable: false, Source: TreeEntriesTableName},
 }
 
-func newTreeEntriesTable() *treeEntriesTable {
-	return new(treeEntriesTable)
+func newTreeEntriesTable(pool *RepositoryPool) *treeEntriesTable {
+	return &treeEntriesTable{checksumable: checksumable{pool}}
 }
 
 var _ Table = (*treeEntriesTable)(nil)
@@ -132,13 +133,13 @@ func (r treeEntriesTable) String() string {
 }
 
 // IndexKeyValues implements the sql.IndexableTable interface.
-func (*treeEntriesTable) IndexKeyValues(
+func (r *treeEntriesTable) IndexKeyValues(
 	ctx *sql.Context,
 	colNames []string,
 ) (sql.PartitionIndexKeyValueIter, error) {
 	return newPartitionedIndexKeyValueIter(
 		ctx,
-		newTreeEntriesTable(),
+		newTreeEntriesTable(r.pool),
 		colNames,
 		newTreeEntriesKeyValueIter,
 	)

--- a/tree_entries_test.go
+++ b/tree_entries_test.go
@@ -14,7 +14,7 @@ func TestTreeEntriesTable(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newTreeEntriesTable()
+	table := newTreeEntriesTable(poolFromCtx(t, ctx))
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)
@@ -32,7 +32,7 @@ func TestTreeEntriesPushdown(t *testing.T) {
 	ctx, _, cleanup := setup(t)
 	defer cleanup()
 
-	table := newTreeEntriesTable()
+	table := newTreeEntriesTable(poolFromCtx(t, ctx))
 
 	rows, err := tableToRows(ctx, table)
 	require.NoError(err)


### PR DESCRIPTION
Closes #661 

Depends on https://github.com/src-d/go-mysql-server/pull/583

Tests will fail until that PR is merged and this is updated.

Basically, this implements the new `sql.Checksumable` interface in each table so the engine can perform the checksums on the repos.

How is the checksum implemented?
With a hash built using the repo ID, all the reference names and the hashes they point to and the checksum of all their packfiles.

If there's a single thing of those that changed, the checksum will be different.

Bad part of this? Pool is needed again in the tables :/ The checksums are checked as part of the init phase of the engine, and there is no context to get the repos from.