### PR TITLE
Set log level

### DIFF
--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -108,7 +108,10 @@ func NewDatabaseEngine(
 func (c *Server) Execute(args []string) error {
 	if c.Verbose {
 		logrus.SetLevel(logrus.DebugLevel)
-	} else {
+	}
+
+	// info is the default log level
+	if c.LogLevel != "info" {
 		level, err := logrus.ParseLevel(c.LogLevel)
 		if err != nil {
 			return fmt.Errorf("cannot parse log level: %s", err.Error())

--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -62,6 +62,7 @@ type Server struct {
 	DisableGit    bool           `long:"no-git" description:"disable the load of git standard repositories."`
 	DisableSiva   bool           `long:"no-siva" description:"disable the load of siva files."`
 	Verbose       bool           `short:"v" description:"Activates the verbose mode"`
+	LogLevel      string         `long:"log-level" env:"GITBASE_LOG_LEVEL" choice:"info" choice:"debug" choice:"warning" choice:"error" choice:"fatal" default:"info" description:"logging level"`
 }
 
 type jaegerLogrus struct {
@@ -107,6 +108,12 @@ func NewDatabaseEngine(
 func (c *Server) Execute(args []string) error {
 	if c.Verbose {
 		logrus.SetLevel(logrus.DebugLevel)
+	} else {
+		level, err := logrus.ParseLevel(c.LogLevel)
+		if err != nil {
+			return fmt.Errorf("cannot parse log level: %s", err.Error())
+		}
+		logrus.SetLevel(level)
 	}
 
 	var err error
@@ -127,7 +134,7 @@ func (c *Server) Execute(args []string) error {
 		c.userAuth = auth.NewNativeSingle(c.User, c.Password, permissions)
 	}
 
-	c.userAuth = auth.NewAudit(c.userAuth, auth.NewAuditLog(logrus.New()))
+	c.userAuth = auth.NewAudit(c.userAuth, auth.NewAuditLog(logrus.StandardLogger()))
 	if err := c.buildDatabase(); err != nil {
 		logrus.WithField("error", err).Fatal("unable to initialize database engine")
 		return err

--- a/docs/using-gitbase/configuration.md
+++ b/docs/using-gitbase/configuration.md
@@ -17,6 +17,7 @@
 | `GITBASE_CONNECTION_TIMEOUT` | timeout in seconds used for client connections on write and reads. No timeout by default.     |
 | `GITBASE_USER_FILE`          | JSON file with user credentials                                                    |
 | `GITBASE_MAX_UAST_BLOB_SIZE`          | Max size of blobs to send to be parsed by bblfsh. Default: 5242880 (5MB)                                                    |
+| `GITBASE_LOG_LEVEL`          | minimum logging level to show, use `fatal` to suppress most messages. Default: `info` |
 
 ### Jaeger tracing variables
 
@@ -67,31 +68,43 @@ stops the query. With GITBASE_SKIP_GIT_ERRORS variable it won't
 complain and just skip those rows or repositories.
 
 Help Options:
-  -h, --help             Show this help message
+  -h, --help                                           Show this help message
 
 [server command options]
-      -d, --directories= Path where the git repositories are located (standard and siva), multiple directories can be
-                         defined. Accepts globs.
-          --depth=       load repositories looking at less than <depth> nested subdirectories. (default: 1000)
-          --host=        Host where the server is going to listen (default: localhost)
-      -p, --port=        Port where the server is going to listen (default: 3306)
-      -u, --user=        User name used for connection (default: root)
-      -P, --password=    Password used for connection
-      -U, --user-file=   JSON file with credentials list [$GITBASE_USER_FILE]
-      -t, --timeout=     Timeout in seconds used for connections [$GITBASE_CONNECTION_TIMEOUT]
-      -i, --index=       Directory where the gitbase indexes information will be persisted. (default:
-                         /var/lib/gitbase/index) [$GITBASE_INDEX_DIR]
-          --cache=       Object cache size in megabytes (default: 512) [$GITBASE_CACHESIZE_MB]
-          --parallelism= Maximum number of parallel threads per table. By default, it's the number of CPU cores. 0
-                         means default, 1 means disabled.
-          --no-squash    Disables the table squashing.
-          --trace        Enables jaeger tracing [$GITBASE_TRACE]
-      -r, --readonly     Only allow read queries. This disables creating and deleting indexes as well. Cannot be used
-                         with --user-file. [$GITBASE_READONLY]
-          --no-git       disable the load of git standard repositories.
-          --no-siva      disable the load of siva files.
-      -v                 Activates the verbose mode
-
+          --db=                                        Database name (default: gitbase)
+      -d, --directories=                               Path where the git repositories are located
+                                                       (standard and siva), multiple directories can
+                                                       be defined. Accepts globs.
+          --depth=                                     load repositories looking at less than
+                                                       <depth> nested subdirectories. (default: 1000)
+          --host=                                      Host where the server is going to listen
+                                                       (default: localhost)
+      -p, --port=                                      Port where the server is going to listen
+                                                       (default: 3306)
+      -u, --user=                                      User name used for connection (default: root)
+      -P, --password=                                  Password used for connection
+      -U, --user-file=                                 JSON file with credentials list
+                                                       [$GITBASE_USER_FILE]
+      -t, --timeout=                                   Timeout in seconds used for connections
+                                                       [$GITBASE_CONNECTION_TIMEOUT]
+      -i, --index=                                     Directory where the gitbase indexes
+                                                       information will be persisted. (default:
+                                                       /var/lib/gitbase/index) [$GITBASE_INDEX_DIR]
+          --cache=                                     Object cache size in megabytes (default: 512)
+                                                       [$GITBASE_CACHESIZE_MB]
+          --parallelism=                               Maximum number of parallel threads per table.
+                                                       By default, it's the number of CPU cores. 0
+                                                       means default, 1 means disabled.
+          --no-squash                                  Disables the table squashing.
+          --trace                                      Enables jaeger tracing [$GITBASE_TRACE]
+      -r, --readonly                                   Only allow read queries. This disables
+                                                       creating and deleting indexes as well. Cannot
+                                                       be used with --user-file. [$GITBASE_READONLY]
+          --no-git                                     disable the load of git standard repositories.
+          --no-siva                                    disable the load of siva files.
+      -v                                               Activates the verbose mode
+          --log-level=[info|debug|warning|error|fatal] logging level (default: info)
+                                                       [$GITBASE_LOG_LEVEL]
 ```
 ## User credentials
 


### PR DESCRIPTION
You can disable errors setting the log level to `fatal`.

Fixes #677 