### PR TITLE
Remove custom bblfsh build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,6 @@ $(MAKEFILE):
 
 -include $(MAKEFILE)
 
-# we still need to do this for windows
-bblfsh-client:
-	cd vendor/gopkg.in/bblfsh/client-go.v3 && make dependencies
-
-dependencies: bblfsh-client
-
 upgrade:
 	go run tools/rev-upgrade/main.go -p $(UPGRADE_PRJ) -r $(UPGRADE_REV)
 


### PR DESCRIPTION
This is causing the following error on `make dependencies` after bblfsh sdk update:

```
11:50 $ make dependencies
cd vendor/gopkg.in/bblfsh/client-go.v3 && make dependencies
make[1]: Entering directory 'work/src/github.com/src-d/gitbase/vendor/gopkg.in/bblfsh/client-go.v3'
go get -v -t -t ./...
github.com/src-d/gitbase/vendor/gopkg.in/bblfsh/client-go.v3/cmd/bblfsh-cli
# github.com/src-d/gitbase/vendor/gopkg.in/bblfsh/client-go.v3/cmd/bblfsh-cli
cmd/bblfsh-cli/main.go:92:30: cannot use ast (type "github.com/src-d/gitbase/vendor/gopkg.in/bblfsh/sdk.v2/uast/nodes".Node) as type "gopkg.in/bblfsh/sdk.v2/uast/nodes".Node in argument to uastyml.Marshal:
	"github.com/src-d/gitbase/vendor/gopkg.in/bblfsh/sdk.v2/uast/nodes".Node does not implement "gopkg.in/bblfsh/sdk.v2/uast/nodes".Node (wrong type for Clone method)
		have Clone() "github.com/src-d/gitbase/vendor/gopkg.in/bblfsh/sdk.v2/uast/nodes".Node
		want Clone() "gopkg.in/bblfsh/sdk.v2/uast/nodes".Node
.ci/Makefile.main:125: recipe for target 'dependencies' failed
make[1]: *** [dependencies] Error 2
make[1]: Leaving directory 'work/src/github.com/src-d/gitbase/vendor/gopkg.in/bblfsh/client-go.v3'
Makefile:21: recipe for target 'bblfsh-client' failed
make: *** [bblfsh-client] Error 2

```

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->