### PR TITLE
no init git-log all

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -163,9 +163,7 @@ func (i *commitIter) init() error {
 		i.iter, err = NewCommitsByHashIter(i.repo, i.hashes)
 	} else {
 		i.iter, err =
-			i.repo.Log(&git.LogOptions{
-				All: true,
-			})
+			i.repo.Log(&git.LogOptions{})
 	}
 
 	return err


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

Closes https://github.com/src-d/gitbase/issues/725

I'm not sure if it's a best use case (I tried different approaches), but I'm not sure if it can be optimized without optimization options in go-git.
So far, I've removed `Log:All` from commit's init iterator.