### PR TITLE
Add a nodeSelector tag for Jenkins on k8s

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
       label 'regression-gitbase'
       inheritFrom 'performance'
       defaultContainer 'regression-gitbase'
+      nodeSelector 'srcd.host/type=jenkins-worker'
       containerTemplate {
         name 'regression-gitbase'
         image 'srcd/regression-gitbase:v0.2.0'


### PR DESCRIPTION
This adds a `nodeSelector` for Jenkins, as it inherits from perfomance it doesn't use the one set in the settings.