### PR TITLE
command: skip a directory if gitbase has no permission to read it

### DIFF
--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -309,6 +309,9 @@ func (c *Server) addMatch(match string) error {
 	initDepth := strings.Count(root, string(os.PathSeparator))
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsPermission(err) {
+				return filepath.SkipDir
+			}
 			return err
 		}
 

--- a/cmd/gitbase/command/server_test.go
+++ b/cmd/gitbase/command/server_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"os"
 	"testing"
 
 	"github.com/src-d/gitbase"
@@ -10,12 +11,22 @@ import (
 func TestAddMatch(t *testing.T) {
 	require := require.New(t)
 
+	notPermissionDir := "../../../_testdata/not-permission/"
+	fi, err := os.Stat(notPermissionDir)
+	require.NoError(err)
+
+	require.NoError(os.Chmod(notPermissionDir, 0))
+	defer func() {
+		require.NoError(os.Chmod(notPermissionDir, fi.Mode()))
+	}()
+
 	expected := []struct {
 		path string
 		err  func(error, ...interface{})
 	}{
 		{"../../../_testdata/repositories/", require.NoError},
 		{"../../../_testdata/repositories-link/", require.NoError},
+		{notPermissionDir, require.NoError},
 		{"../../../_testdata/repositories-not-exist/", require.Error},
 	}
 	c := &Server{pool: gitbase.NewRepositoryPool(0)}


### PR DESCRIPTION
Fixes #718

When a child of one of the paths given to the gitbase server is not
readable because of permissions, the repo finding process just
stopped and no repository was added to the pool.
This skips a directory if there are no permissions to read it, so
the process can continue adding repositories to the pool as usual.
