### PR TITLE
gitbase: ignore object.ErrNotFound on new commits iter

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -270,7 +270,7 @@ func (i *commitIter) Next() (*object.Commit, error) {
 
 		commit, err := i.repo.CommitObject(hash)
 		if err != nil {
-			if i.skipGitErrors {
+			if i.skipGitErrors || err == plumbing.ErrObjectNotFound {
 				continue
 			}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -329,6 +329,23 @@ func TestIntegration(t *testing.T) {
 				{"Ignore List", int32(1)},
 			},
 		},
+		{
+			`
+			SELECT 
+				repository_id,
+				contributor_count 
+			FROM (
+				SELECT 
+					repository_id, 
+					COUNT(DISTINCT commit_author_email) AS contributor_count 
+				FROM commits 
+				GROUP BY repository_id
+			) AS q 
+			ORDER BY contributor_count DESC 
+			LIMIT 10
+			`,
+			[]sql.Row{{"worktree", int32(9)}},
+		},
 	}
 
 	runTests := func(t *testing.T) {


### PR DESCRIPTION
Fixes #741 