### PR TITLE
skip references pointing to objects that are not commits

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -230,12 +230,7 @@ func (i *commitIter) loadNextRef() (err error) {
 			return err
 		}
 
-		if i.ref.Type() != plumbing.HashReference {
-			i.ref = nil
-			continue
-		}
-
-		obj, err := i.repo.Object(plumbing.AnyObject, i.ref.Hash())
+		ignored, err := isIgnoredReference(i.repo.Repository, i.ref)
 		if err != nil {
 			if i.skipGitErrors {
 				continue
@@ -244,7 +239,7 @@ func (i *commitIter) loadNextRef() (err error) {
 			return err
 		}
 
-		if obj.Type() != plumbing.CommitObject {
+		if ignored {
 			continue
 		}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -594,7 +594,7 @@ func TestMissingHeadRefs(t *testing.T) {
 
 	rows, err := sql.RowIterToRows(iter)
 	require.NoError(err)
-	require.Len(rows, 56)
+	require.Len(rows, 54)
 }
 
 func BenchmarkQueries(b *testing.B) {

--- a/ref_commits.go
+++ b/ref_commits.go
@@ -306,7 +306,16 @@ func (i *refCommitsRowIter) next() (sql.Row, error) {
 					return nil, err
 				}
 
-				if ref.Type() != plumbing.HashReference {
+				ignored, err := isIgnoredReference(i.repo.Repository, ref)
+				if err != nil {
+					if i.skipGitErrors {
+						continue
+					}
+
+					return nil, err
+				}
+
+				if ignored {
 					continue
 				}
 			} else {

--- a/squash_iterator.go
+++ b/squash_iterator.go
@@ -474,7 +474,16 @@ func (i *squashRefIter) Advance() error {
 			}
 		}
 
-		if ref.Type() != plumbing.HashReference {
+		ignored, err := isIgnoredReference(i.repo.Repository, ref)
+		if err != nil {
+			if i.skipGitErrors {
+				continue
+			}
+
+			return err
+		}
+
+		if ignored {
 			continue
 		}
 
@@ -715,11 +724,16 @@ func (i *squashRepoRefsIter) Advance() error {
 			}
 		}
 
-		if ref.Type() != plumbing.HashReference {
-			logrus.WithFields(logrus.Fields{
-				"type": ref.Type(),
-				"ref":  ref.Name(),
-			}).Debug("ignoring reference, it's not a hash reference")
+		ignored, err := isIgnoredReference(i.repos.Repository().Repository, ref)
+		if err != nil {
+			if i.skipGitErrors {
+				continue
+			}
+
+			return err
+		}
+
+		if ignored {
 			continue
 		}
 
@@ -859,7 +873,16 @@ func (i *squashRemoteRefsIter) Advance() error {
 			}
 		}
 
-		if ref.Type() != plumbing.HashReference {
+		ignored, err := isIgnoredReference(i.Repository().Repository, ref)
+		if err != nil {
+			if i.skipGitErrors {
+				continue
+			}
+
+			return err
+		}
+
+		if ignored {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #745

On all iterators where references are used only hash references
are used. But we're not taking into account that hash references
can point to any kind of object, not only commit objects, which
are the only objects we care about for the references table.

This fix was already applied on the new commits iterator that
walks the history skipping unreachable commits, but it was not
consistent with the rest of the iterators, which only check if the
reference was a hash reference or not. Now this behavior is
consistent in all iterators.

`isIgnoredReference` function has been added to abstract all this
logic away so if we ever need to change the logic of this we will
only have to replace it in one place instead of being scattered
all over the codebase.

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->