### PR TITLE
rule: parallelize projects calling UAST not under exchanges

### DIFF
--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -94,7 +94,11 @@ func NewDatabaseEngine(
 		ab = ab.AddPostAnalyzeRule(rule.SquashJoinsRule, rule.SquashJoins)
 	}
 
-	a := ab.Build()
+	a := ab.AddPostAnalyzeRule(
+		rule.ParallelizeUASTProjectionsRule,
+		rule.ParallelizeUASTProjections,
+	).Build()
+
 	engine := sqle.New(catalog, a, &sqle.Config{
 		VersionPostfix: version,
 		Auth:           userAuth,

--- a/internal/rule/parallel_project.go
+++ b/internal/rule/parallel_project.go
@@ -1,0 +1,239 @@
+package rule
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
+)
+
+type parallelProject struct {
+	*plan.Project
+	parallelism int
+}
+
+func newParallelProject(
+	projection []sql.Expression,
+	child sql.Node,
+	parallelism int,
+) *parallelProject {
+	return &parallelProject{
+		plan.NewProject(projection, child),
+		parallelism,
+	}
+}
+
+func (p *parallelProject) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	span, ctx := ctx.Span(
+		"plan.Project",
+		opentracing.Tag{
+			Key:   "projections",
+			Value: len(p.Projections),
+		},
+		opentracing.Tag{
+			Key:   "parallelism",
+			Value: p.parallelism,
+		},
+	)
+
+	iter, err := p.Child.RowIter(ctx)
+	if err != nil {
+		span.Finish()
+		return nil, err
+	}
+
+	return sql.NewSpanIter(
+		span,
+		newParallelIter(p.Projections, iter, ctx, p.parallelism),
+	), nil
+}
+
+func (p *parallelProject) TransformUp(f sql.TransformNodeFunc) (sql.Node, error) {
+	child, err := p.Child.TransformUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return f(newParallelProject(p.Projections, child, p.parallelism))
+}
+
+func (p *parallelProject) TransformExpressionsUp(f sql.TransformExprFunc) (sql.Node, error) {
+	var exprs = make([]sql.Expression, len(p.Projections))
+	for i, e := range p.Projections {
+		expr, err := e.TransformUp(f)
+		if err != nil {
+			return nil, err
+		}
+
+		exprs[i] = expr
+	}
+
+	child, err := p.Child.TransformExpressionsUp(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return newParallelProject(exprs, child, p.parallelism), nil
+}
+
+func (p *parallelProject) String() string {
+	pr := sql.NewTreePrinter()
+	var exprs = make([]string, len(p.Projections))
+	for i, expr := range p.Projections {
+		exprs[i] = expr.String()
+	}
+
+	_ = pr.WriteNode(
+		"gitbase.ParallelProject(%s, parallelism=%d)",
+		strings.Join(exprs, ", "),
+		p.parallelism,
+	)
+
+	_ = pr.WriteChildren(p.Child.String())
+	return pr.String()
+}
+
+type parallelIter struct {
+	projections []sql.Expression
+	child       sql.RowIter
+	ctx         *sql.Context
+	parallelism int
+
+	cancel context.CancelFunc
+	rows   chan sql.Row
+	errors chan error
+	done   bool
+
+	mut      sync.Mutex
+	finished bool
+}
+
+func newParallelIter(
+	projections []sql.Expression,
+	child sql.RowIter,
+	ctx *sql.Context,
+	parallelism int,
+) *parallelIter {
+	var cancel context.CancelFunc
+	ctx.Context, cancel = context.WithCancel(ctx.Context)
+
+	return &parallelIter{
+		projections: projections,
+		child:       child,
+		ctx:         ctx,
+		parallelism: parallelism,
+		cancel:      cancel,
+		errors:      make(chan error, parallelism),
+	}
+}
+
+func (i *parallelIter) Next() (sql.Row, error) {
+	if i.done {
+		return nil, io.EOF
+	}
+
+	if i.rows == nil {
+		i.rows = make(chan sql.Row, i.parallelism)
+		go i.start()
+	}
+
+	select {
+	case row, ok := <-i.rows:
+		if !ok {
+			i.close()
+			return nil, io.EOF
+		}
+		return row, nil
+	case err := <-i.errors:
+		i.close()
+		return nil, err
+	}
+}
+
+func (i *parallelIter) nextRow() (sql.Row, bool) {
+	i.mut.Lock()
+	defer i.mut.Unlock()
+
+	if i.finished {
+		return nil, true
+	}
+
+	row, err := i.child.Next()
+	if err != nil {
+		if err == io.EOF {
+			i.finished = true
+		} else {
+			i.errors <- err
+		}
+		return nil, true
+	}
+
+	return row, false
+}
+
+func (i *parallelIter) start() {
+	var wg sync.WaitGroup
+	wg.Add(i.parallelism)
+	for j := 0; j < i.parallelism; j++ {
+		go func() {
+			defer wg.Done()
+
+			for {
+				select {
+				case <-i.ctx.Done():
+					i.errors <- context.Canceled
+					return
+				default:
+				}
+
+				row, stop := i.nextRow()
+				if stop {
+					return
+				}
+
+				row, err := project(i.ctx, i.projections, row)
+				if err != nil {
+					i.errors <- err
+					return
+				}
+
+				i.rows <- row
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(i.rows)
+}
+
+func (i *parallelIter) close() {
+	if !i.done {
+		i.cancel()
+		i.done = true
+	}
+}
+
+func (i *parallelIter) Close() error {
+	i.close()
+	return i.child.Close()
+}
+
+func project(
+	s *sql.Context,
+	projections []sql.Expression,
+	row sql.Row,
+) (sql.Row, error) {
+	var fields []interface{}
+	for _, expr := range projections {
+		f, err := expr.Eval(s, row)
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, f)
+	}
+	return sql.NewRow(fields...), nil
+}

--- a/internal/rule/parallel_project_test.go
+++ b/internal/rule/parallel_project_test.go
@@ -1,0 +1,52 @@
+package rule
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/mem"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
+)
+
+func TestParallelProject(t *testing.T) {
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+	child := mem.NewTable("test", sql.Schema{
+		{Name: "col1", Type: sql.Text, Nullable: true},
+		{Name: "col2", Type: sql.Text, Nullable: true},
+	})
+
+	var input, expected []sql.Row
+	for i := 1; i < 500; i++ {
+		input = append(input, sql.Row{
+			fmt.Sprintf("col1_%d", i), fmt.Sprintf("col2_%d", i),
+		})
+
+		expected = append(expected, sql.Row{fmt.Sprintf("col2_%d", i)})
+	}
+
+	for _, row := range input {
+		require.NoError(child.Insert(sql.NewEmptyContext(), row))
+	}
+
+	p := newParallelProject(
+		[]sql.Expression{expression.NewGetField(1, sql.Text, "col2", true)},
+		plan.NewResolvedTable(child),
+		runtime.NumCPU(),
+	)
+
+	iter, err := p.RowIter(ctx)
+	require.NoError(err)
+
+	rows, err := sql.RowIterToRows(iter)
+	require.NoError(err)
+	require.ElementsMatch(expected, rows)
+
+	_, err = iter.Next()
+	require.Equal(io.EOF, err)
+}

--- a/internal/rule/parallelize_uast.go
+++ b/internal/rule/parallelize_uast.go
@@ -1,0 +1,76 @@
+package rule
+
+import (
+	"github.com/src-d/gitbase/internal/function"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
+)
+
+// ParallelizeUASTProjectionsRule is the name of the rule.
+const ParallelizeUASTProjectionsRule = "parallelize_uast_projections"
+
+// ParallelizeUASTProjections is a rule that whenever it finds a projection
+// with a call to any uast function, it replaces it with a parallel version
+// of the project node to execute several bblfsh requests in parallel. It
+// will only do so if the project is not under an exchange node.
+func ParallelizeUASTProjections(
+	ctx *sql.Context,
+	a *analyzer.Analyzer,
+	n sql.Node,
+) (sql.Node, error) {
+	if a.Parallelism <= 1 {
+		return n, nil
+	}
+
+	return n.TransformUp(func(n sql.Node) (sql.Node, error) {
+		switch n := n.(type) {
+		case *plan.Project:
+			if callsUAST(n.Projections) {
+				return newParallelProject(n.Projections, n.Child, a.Parallelism), nil
+			}
+
+			return n, nil
+		case *plan.Exchange:
+			child, err := n.Child.TransformUp(removeParallelProjects)
+			if err != nil {
+				return nil, err
+			}
+
+			return plan.NewExchange(n.Parallelism, child), nil
+		default:
+			return n, nil
+		}
+	})
+}
+
+func removeParallelProjects(n sql.Node) (sql.Node, error) {
+	p, ok := n.(*parallelProject)
+	if !ok {
+		return n, nil
+	}
+
+	return plan.NewProject(p.Projections, p.Child), nil
+}
+
+func callsUAST(exprs []sql.Expression) bool {
+	var seen bool
+	for _, e := range exprs {
+		expression.Inspect(e, func(e sql.Expression) bool {
+			switch e.(type) {
+			case *function.UAST, *function.UASTMode:
+				seen = true
+				return false
+			}
+
+			return true
+		})
+
+		if seen {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/rule/parallelize_uast_test.go
+++ b/internal/rule/parallelize_uast_test.go
@@ -1,0 +1,76 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/src-d/gitbase"
+	"github.com/src-d/gitbase/internal/function"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/analyzer"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/plan"
+)
+
+func TestParallelizeUASTProjections(t *testing.T) {
+	require := require.New(t)
+
+	tables := gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(0)).Tables()
+
+	uastFn, err := function.NewUAST(
+		expression.NewGetFieldWithTable(0, sql.Blob, "files", "blob_content", false),
+	)
+	require.NoError(err)
+
+	uastModeFn := function.NewUASTMode(
+		expression.NewLiteral("semantic", sql.Text),
+		expression.NewGetFieldWithTable(0, sql.Blob, "files", "blob_content", false),
+		expression.NewLiteral("Go", sql.Text),
+	)
+
+	node := plan.NewProject(
+		[]sql.Expression{
+			uastModeFn,
+			uastFn,
+		},
+		plan.NewExchange(
+			5,
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias(
+						uastFn,
+						"foo",
+					),
+				},
+				plan.NewResolvedTable(tables[gitbase.FilesTableName]),
+			),
+		),
+	)
+
+	a := analyzer.NewBuilder(nil).WithParallelism(4).Build()
+
+	result, err := ParallelizeUASTProjections(sql.NewEmptyContext(), a, node)
+	require.NoError(err)
+
+	expected := newParallelProject(
+		[]sql.Expression{
+			uastModeFn,
+			uastFn,
+		},
+		plan.NewExchange(
+			5,
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias(
+						uastFn,
+						"foo",
+					),
+				},
+				plan.NewResolvedTable(tables[gitbase.FilesTableName]),
+			),
+		),
+		4,
+	)
+
+	require.Equal(expected, result)
+}


### PR DESCRIPTION
Fixes #766

Since rows are iterated serially (except for exchange nodes), when
a Project node calls UAST, it's processed one at a time, which
underutilizes the resources in the machine.

When a Project calls UAST or UAST_MODE and is not under an Exchange
node, which already parallelizes its children, replaces the project
with a special node called parallelProject, which is essentially a
project that keeps up to N goroutines processing rows, where N is
the parallelism value of gitbase.

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->