### PR TITLE
Kind of regression - revert commit files

### DIFF
--- a/commit_files.go
+++ b/commit_files.go
@@ -193,18 +193,17 @@ func (i *commitFilesRowIter) Next() (sql.Row, error) {
 }
 
 func (i *commitFilesRowIter) init() error {
+	var err error
 	if len(i.commitHashes) > 0 {
-		i.commits = newCommitsByHashIter(i.repo, i.commitHashes)
+		i.commits, err = NewCommitsByHashIter(i.repo, i.commitHashes)
 	} else {
-		iter, err := newCommitIter(i.repo, i.skipGitErrors)
-		if err != nil {
-			return err
-		}
-
-		i.commits = iter
+		i.commits, err = i.repo.
+			Log(&git.LogOptions{
+				All: true,
+			})
 	}
 
-	return nil
+	return err
 }
 
 func (i *commitFilesRowIter) nextFromIndex() (sql.Row, error) {

--- a/commit_trees.go
+++ b/commit_trees.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 
+	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
@@ -211,18 +212,16 @@ func (i *commitTreesRowIter) Next() (sql.Row, error) {
 }
 
 func (i *commitTreesRowIter) init() error {
+	var err error
 	if len(i.commitHashes) > 0 {
-		i.commits = newCommitsByHashIter(i.repo, i.commitHashes)
+		i.commits, err = NewCommitsByHashIter(i.repo, i.commitHashes)
 	} else {
-		iter, err := newCommitIter(i.repo, i.skipGitErrors)
-		if err != nil {
-			return err
-		}
-
-		i.commits = iter
+		i.commits, err = i.repo.Log(&git.LogOptions{
+			All: true,
+		})
 	}
 
-	return nil
+	return err
 }
 
 var commitTreesHashIdx = CommitTreesSchema.IndexOf("commit_hash", CommitTreesTableName)


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

Fixes https://github.com/src-d/gitbase/issues/769

This PR does not really implements anything. It reverts commit files (commits, commit_files, commit_trees, commit_blobs) to the revision `9748ee33ec694003c72d50763e3180b6238bc673` (just before walk commits in history lazily 0c6afe85544c67b12fe177e02949e0d7f1edb55f).

So, it's kind of regression. **We don't need to merge this PR** If we figure out how to keep current implementation (without `Log:All`) and fix the regression issue #769 