### PR TITLE
gitbase: remove git.Log from index commit iterator

### DIFF
--- a/commits.go
+++ b/commits.go
@@ -3,7 +3,6 @@ package gitbase
 import (
 	"io"
 
-	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-mysql-server.v0/sql"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -414,10 +413,7 @@ func newCommitsKeyValueIter(
 		return nil, err
 	}
 
-	commits, err :=
-		repo.Log(&git.LogOptions{
-			All: true,
-		})
+	commits, err := newCommitIter(repo, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #769

git.Log was being passed as commit iter to the index iterator, but
the new commitIter should be passed instead. That generated a
discrepancy between the results of indexes and the sames queries
with no indexes.

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->