### PR TITLE
Close iterators

### DIFF
--- a/commit_trees.go
+++ b/commit_trees.go
@@ -330,11 +330,13 @@ func (i *commitTreesRowIter) Close() error {
 		i.trees.Close()
 	}
 
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	if i.index != nil {
 		return i.index.Close()
 	}
-
-	i.repo.Close()
 
 	return nil
 }

--- a/partition.go
+++ b/partition.go
@@ -227,5 +227,8 @@ func (i *partitionedIndexKeyValueIter) Next() (sql.Partition, sql.IndexKeyValueI
 }
 
 func (i *partitionedIndexKeyValueIter) Close() error {
-	return i.partitions.Close()
+	if i.partitions != nil {
+		return i.partitions.Close()
+	}
+	return nil
 }

--- a/ref_commits.go
+++ b/ref_commits.go
@@ -361,11 +361,13 @@ func (i *refCommitsRowIter) Close() error {
 		i.refs.Close()
 	}
 
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	if i.index != nil {
 		return i.index.Close()
 	}
-
-	i.repo.Close()
 
 	return nil
 }
@@ -441,5 +443,11 @@ func (i *indexedCommitIter) Next() (*object.Commit, int, error) {
 		}
 
 		return c, frame.idx, nil
+	}
+}
+
+func (i *indexedCommitIter) Close() {
+	if i.repo != nil {
+		i.repo.Close()
 	}
 }

--- a/references.go
+++ b/references.go
@@ -320,11 +320,13 @@ func (i *refRowIter) Close() error {
 		i.iter.Close()
 	}
 
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	if i.index != nil {
 		return i.index.Close()
 	}
-
-	i.repo.Close()
 
 	return nil
 }

--- a/repositories.go
+++ b/repositories.go
@@ -151,5 +151,8 @@ func (i *repositoriesRowIter) Next() (sql.Row, error) {
 
 func (i *repositoriesRowIter) Close() error {
 	i.visited = true
+	if i.repo != nil {
+		i.repo.Close()
+	}
 	return nil
 }

--- a/squash_iterator.go
+++ b/squash_iterator.go
@@ -56,7 +56,13 @@ func NewAllReposIter(filters sql.Expression) ReposIter {
 }
 
 func (i *squashReposIter) Repo() *Repository { return i.repo }
-func (i *squashReposIter) Close() error      { return nil }
+func (i *squashReposIter) Close() error {
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
+	return nil
+}
 func (i *squashReposIter) New(ctx *sql.Context, repo *Repository) (ChainableIter, error) {
 	session, err := getSession(ctx)
 	if err != nil {
@@ -140,7 +146,13 @@ func NewAllRemotesIter(filters sql.Expression) RemotesIter {
 }
 
 func (i *squashRemoteIter) Remote() *Remote { return i.remote }
-func (i *squashRemoteIter) Close() error    { return nil }
+func (i *squashRemoteIter) Close() error {
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
+	return nil
+}
 func (i *squashRemoteIter) New(ctx *sql.Context, repo *Repository) (ChainableIter, error) {
 	session, err := getSession(ctx)
 	if err != nil {
@@ -403,6 +415,9 @@ func (i *squashRefIter) Close() error {
 	if i.refs != nil {
 		i.refs.Close()
 	}
+	if i.repo != nil {
+		i.repo.Close()
+	}
 	return i.repos.Close()
 }
 func (i *squashRefIter) New(ctx *sql.Context, repo *Repository) (ChainableIter, error) {
@@ -523,6 +538,10 @@ func NewIndexRefsIter(filters sql.Expression, index sql.IndexLookup) RefsIter {
 func (i *squashRefIndexIter) Repository() *Repository { return i.repo }
 func (i *squashRefIndexIter) Ref() *Ref               { return i.ref }
 func (i *squashRefIndexIter) Close() error {
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return i.iter.Close()
 }
 func (i *squashRefIndexIter) New(ctx *sql.Context, repo *Repository) (ChainableIter, error) {
@@ -778,8 +797,6 @@ func NewRemoteRefsIter(
 func (i *squashRemoteRefsIter) Repository() *Repository { return i.remotes.Repository() }
 func (i *squashRemoteRefsIter) Ref() *Ref               { return i.ref }
 func (i *squashRemoteRefsIter) Close() error {
-	i.Repository().Close()
-
 	if i.refs != nil {
 		i.refs.Close()
 	}
@@ -929,7 +946,9 @@ func (i *squashRefRefCommitsIter) Close() error {
 		i.refs.Close()
 	}
 
-	i.Repository().Close()
+	if i.commits != nil {
+		i.commits.Close()
+	}
 	return nil
 }
 func (i *squashRefRefCommitsIter) New(ctx *sql.Context, repo *Repository) (ChainableIter, error) {
@@ -1202,7 +1221,9 @@ func (i *squashRefCommitsIndexIter) Schema() sql.Schema {
 	return RefCommitsSchema
 }
 func (i *squashRefCommitsIndexIter) Close() error {
-	i.repo.Close()
+	if i.repo != nil {
+		i.repo.Close()
+	}
 	return i.iter.Close()
 }
 
@@ -1226,7 +1247,6 @@ func (i *squashRefCommitCommitsIter) Close() error {
 		i.refCommits.Close()
 	}
 
-	i.Repository().Close()
 	return nil
 }
 func (i *squashRefCommitCommitsIter) New(ctx *sql.Context, repo *Repository) (ChainableIter, error) {
@@ -1297,8 +1317,10 @@ func (i *squashCommitsIter) Close() error {
 	if i.commits != nil {
 		i.commits.Close()
 	}
+	if i.repo != nil {
+		i.repo.Close()
+	}
 
-	i.repo.Close()
 	return nil
 }
 func (i *squashCommitsIter) New(ctx *sql.Context, repo *Repository) (ChainableIter, error) {
@@ -1472,7 +1494,10 @@ func (i *squashCommitsIndexIter) Schema() sql.Schema {
 	return CommitsSchema
 }
 func (i *squashCommitsIndexIter) Close() error {
-	i.repo.Close()
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return i.iter.Close()
 }
 
@@ -1498,8 +1523,6 @@ func (i *squashRepoCommitsIter) Close() error {
 	if i.commits != nil {
 		i.commits.Close()
 	}
-
-	i.Repository().Close()
 
 	if i.repos != nil {
 		return i.repos.Close()
@@ -1611,8 +1634,6 @@ func NewRefHEADCommitsIter(
 func (i *squashRefHeadCommitsIter) Repository() *Repository { return i.refs.Repository() }
 func (i *squashRefHeadCommitsIter) Commit() *object.Commit  { return i.commit }
 func (i *squashRefHeadCommitsIter) Close() error {
-	i.Repository().Close()
-
 	if i.refs != nil {
 		return i.refs.Close()
 	}
@@ -1805,7 +1826,10 @@ func (i *squashCommitTreesIndexIter) Schema() sql.Schema {
 	return CommitTreesSchema
 }
 func (i *squashCommitTreesIndexIter) Close() error {
-	i.repo.Close()
+	if i.repo != nil {
+		i.repo.Close()
+	}
+
 	return i.iter.Close()
 }
 
@@ -1837,6 +1861,9 @@ func NewCommitTreesIter(
 func (i *squashCommitTreesIter) Repository() *Repository { return i.commits.Repository() }
 func (i *squashCommitTreesIter) Tree() *object.Tree      { return i.tree }
 func (i *squashCommitTreesIter) Close() error {
+	if i.trees != nil {
+		i.trees.Close()
+	}
 	if i.commits != nil {
 		return i.commits.Close()
 	}
@@ -1952,8 +1979,6 @@ func (i *squashRepoTreeEntriesIter) Close() error {
 	if i.trees != nil {
 		i.trees.Close()
 	}
-
-	i.Repository().Close()
 
 	if i.repos != nil {
 		return i.repos.Close()
@@ -2083,8 +2108,6 @@ func NewCommitMainTreeIter(
 func (i *squashCommitMainTreeIter) Repository() *Repository { return i.commits.Repository() }
 func (i *squashCommitMainTreeIter) Tree() *object.Tree      { return i.tree }
 func (i *squashCommitMainTreeIter) Close() error {
-	i.Repository().Close()
-
 	if i.commits != nil {
 		return i.commits.Close()
 	}
@@ -2247,6 +2270,12 @@ func (i *commitTreeIter) Next() (*object.Tree, error) {
 	}
 }
 
+func (i *commitTreeIter) Close() {
+	if i.repo != nil {
+		i.repo.Close()
+	}
+}
+
 // TreeEntriesIter is a chainable iterator that operates on Tree Entries.
 type TreeEntriesIter interface {
 	ChainableIter
@@ -2277,7 +2306,9 @@ func NewAllTreeEntriesIter(filters sql.Expression) TreeEntriesIter {
 func (i *squashTreeEntriesIter) Repository() *Repository { return i.repo }
 func (i *squashTreeEntriesIter) TreeEntry() *TreeEntry   { return i.entry }
 func (i *squashTreeEntriesIter) Close() error {
-	i.Repository().Close()
+	if i.repo != nil {
+		i.repo.Close()
+	}
 
 	if i.trees != nil {
 		i.trees.Close()
@@ -2448,7 +2479,9 @@ func (i *squashTreeEntriesIndexIter) Schema() sql.Schema {
 	return TreeEntriesSchema
 }
 func (i *squashTreeEntriesIndexIter) Close() error {
-	i.Repository().Close()
+	if i.repo != nil {
+		i.repo.Close()
+	}
 	return i.iter.Close()
 }
 
@@ -2480,8 +2513,6 @@ func NewTreeTreeEntriesIter(
 func (i *squashTreeTreeEntriesIter) Repository() *Repository { return i.trees.Repository() }
 func (i *squashTreeTreeEntriesIter) TreeEntry() *TreeEntry   { return i.entry }
 func (i *squashTreeTreeEntriesIter) Close() error {
-	i.Repository().Close()
-
 	if i.trees != nil {
 		return i.trees.Close()
 	}
@@ -2651,7 +2682,9 @@ func (i *squashCommitBlobsIndexIter) Schema() sql.Schema {
 	return CommitBlobsSchema
 }
 func (i *squashCommitBlobsIndexIter) Close() error {
-	i.Repository().Close()
+	if i.repo != nil {
+		i.repo.Close()
+	}
 	return i.iter.Close()
 }
 
@@ -2688,8 +2721,6 @@ func (i *squashCommitBlobsIter) Close() error {
 	if i.files != nil {
 		i.files.Close()
 	}
-
-	i.Repository().Close()
 
 	if i.commits != nil {
 		return i.commits.Close()
@@ -2820,8 +2851,6 @@ func (i *squashRepoBlobsIter) Close() error {
 	if i.blobs != nil {
 		i.blobs.Close()
 	}
-
-	i.Repository().Close()
 
 	if i.repos != nil {
 		return i.repos.Close()
@@ -3207,7 +3236,6 @@ func (i *squashCommitFilesIter) Close() error {
 		i.files.Close()
 	}
 
-	i.Repository().Close()
 	return i.commits.Close()
 }
 func (i *squashCommitFilesIter) Schema() sql.Schema {
@@ -3315,7 +3343,9 @@ func (i *squashIndexCommitFilesIter) Row() sql.Row            { return i.row }
 func (i *squashIndexCommitFilesIter) Schema() sql.Schema      { return CommitFilesSchema }
 
 func (i *squashIndexCommitFilesIter) Close() error {
-	i.repo.Close()
+	if i.repo != nil {
+		i.repo.Close()
+	}
 	return i.iter.Close()
 }
 
@@ -3391,7 +3421,6 @@ func (i *squashCommitFileFilesIter) Schema() sql.Schema {
 	return append(i.files.Schema(), FilesSchema...)
 }
 func (i *squashCommitFileFilesIter) Close() error {
-	i.Repository().Close()
 	return i.files.Close()
 }
 

--- a/tree_entries.go
+++ b/tree_entries.go
@@ -239,9 +239,9 @@ func (i *treeEntriesRowIter) Close() error {
 	if i.iter != nil {
 		i.iter.Close()
 	}
-
-	i.repo.Close()
-
+	if i.repo != nil {
+		i.repo.Close()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

We have a cascade of iterators. Some iterators are not closing (what breaks a chain).
In this PR I tried to close all possible iterators. Rest of the stuff has to be done in mysql. For some cases (where we pass iterator to tables or to builders) I have a feeling that we never have a chance to close it because either it's wrapped by many interfaced or there is no right place where we can do it.

At least those simple `Close` statements  can partly fix https://github.com/src-d/gitbase/issues/765
