### PR TITLE
makefile: fix adding version in generated binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # Package configuration
 PROJECT = gitbase
 COMMANDS = cmd/gitbase
-GO_BUILD_ARGS += -tags mysql_go_regex
 
 # Including ci Makefile
 CI_REPOSITORY ?= https://github.com/src-d/ci.git
@@ -16,6 +15,8 @@ $(MAKEFILE):
 	git clone --quiet --branch $(CI_VERSION) --depth 1 $(CI_REPOSITORY) $(CI_PATH);
 
 -include $(MAKEFILE)
+
+GO_BUILD_ARGS += -tags mysql_go_regex
 
 upgrade:
 	go run tools/rev-upgrade/main.go -p $(UPGRADE_PRJ) -r $(UPGRADE_REV)
@@ -33,10 +34,9 @@ static-package:
 # target used in the Dockerfile to build the static binary
 static-build: VERSION ?= $(shell git describe --exact-match --tags 2>/dev/null || "dev-$(git rev-parse --short HEAD)$(test -n "`git status --porcelain`" && echo "-dirty" || true)")
 static-build: LD_FLAGS += -linkmode external -extldflags '-static -lz' -s -w
-static-build: GO_BUILD_ARGS += -tags mysql_go_regex
 static-build: GO_BUILD_PATH ?= github.com/src-d/gitbase/...
 static-build:
-	go build -ldflags="$(LD_FLAGS)" -v $(GO_BUILD_ARGS) $(GO_BUILD_PATH)
+	go build -ldflags="$(LD_FLAGS)" -v -tags mysql_go_regex $(GO_BUILD_PATH)
 
 ci-e2e: packages
 	go test ./e2e -gitbase-version="$(TRAVIS_TAG)" \

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 
 	path, err := exec.LookPath(*bin)
 	if err != nil {
-		fmt.Println("gitbase-bin not provided")
+		fmt.Println("gitbase-bin not provided:", err)
 		if *mustRun {
 			os.Exit(1)
 		} else {


### PR DESCRIPTION
Fixes #774 

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->