### PR TITLE
Run regression tests with complexity 0 on PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     stage('PR-run') {
       when { changeRequest target: 'master' }
       steps {
-        sh '/bin/regression --complexity=0 local:HEAD'
+        sh '/bin/regression --complexity=0 remote:master local:HEAD'
       }
     }
     stage('Plot') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,12 @@ pipeline {
         sh '/bin/regression --complexity=2 --csv local:HEAD'
       }
     }
+    stage('PR-run') {
+      when { changeRequest target: 'master' }
+      steps {
+        sh '/bin/regression --complexity=0 local:HEAD'
+      }
+    }
     stage('Plot') {
       when { branch 'master' }
       steps {


### PR DESCRIPTION
This PR allows to execute jenkins regression tests with smaller
repositories than the used on master branch.

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->