### PR TITLE
Upgrade mysql

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -672,7 +672,7 @@
   source = "github.com/src-d/go-git"
 
 [[projects]]
-  digest = "1:328cf8293a551847642352b4853f9b333e958fcfbf21fad4981866d5a8939c81"
+  digest = "1:fc7e1e0d958879bb0eb442e61c264ed214077ed15e00f472998955578ab2c887"
   name = "gopkg.in/src-d/go-mysql-server.v0"
   packages = [
     ".",
@@ -691,7 +691,7 @@
     "sql/plan",
   ]
   pruneopts = "NUT"
-  revision = "0093a7562ad1cf31f179396dfa5be32893059dbb"
+  revision = "3dd441325d1731821eff0495fbf63747c258b8ff"
 
 [[projects]]
   digest = "1:f995136b53497081f1b3f29b99e78a597da6afb2bc6f22908382559a863df4ea"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "gopkg.in/src-d/go-mysql-server.v0"
-  revision = "0093a7562ad1cf31f179396dfa5be32893059dbb"
+  revision = "3dd441325d1731821eff0495fbf63747c258b8ff"
 
 [[constraint]]
   name = "github.com/jessevdk/go-flags"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ $(MAKEFILE):
 
 -include $(MAKEFILE)
 
-GO_BUILD_ARGS += -tags mysql_go_regex
 
 upgrade:
 	go run tools/rev-upgrade/main.go -p $(UPGRADE_PRJ) -r $(UPGRADE_REV)
@@ -36,7 +35,7 @@ static-build: VERSION ?= $(shell git describe --exact-match --tags 2>/dev/null |
 static-build: LD_FLAGS += -linkmode external -extldflags '-static -lz' -s -w
 static-build: GO_BUILD_PATH ?= github.com/src-d/gitbase/...
 static-build:
-	go build -ldflags="$(LD_FLAGS)" -v -tags mysql_go_regex $(GO_BUILD_PATH)
+	go build -ldflags="$(LD_FLAGS)" -v  $(GO_BUILD_PATH)
 
 ci-e2e: packages
 	go test ./e2e -gitbase-version="$(TRAVIS_TAG)" \

--- a/docs/using-gitbase/functions.md
+++ b/docs/using-gitbase/functions.md
@@ -95,4 +95,4 @@ Also, if you want to retrieve values from a non common property, you can pass it
 
 ## Standard functions
 
-You can check standard functions in [`go-mysql-server` documentation](https://github.com/src-d/go-mysql-server/tree/0093a7562ad1cf31f179396dfa5be32893059dbb#custom-functions).
+You can check standard functions in [`go-mysql-server` documentation](https://github.com/src-d/go-mysql-server/tree/3dd441325d1731821eff0495fbf63747c258b8ff#custom-functions).

--- a/docs/using-gitbase/indexes.md
+++ b/docs/using-gitbase/indexes.md
@@ -26,4 +26,4 @@ and for the second query also two indexes will be used and the result will be a 
 
 You can find some more examples in the [examples](./examples.md#create-an-index-for-columns-on-a-table) section.
 
-See [go-mysql-server](https://github.com/src-d/go-mysql-server/tree/0093a7562ad1cf31f179396dfa5be32893059dbb#indexes) documentation for more details
+See [go-mysql-server](https://github.com/src-d/go-mysql-server/tree/3dd441325d1731821eff0495fbf63747c258b8ff#indexes) documentation for more details

--- a/docs/using-gitbase/supported-clients.md
+++ b/docs/using-gitbase/supported-clients.md
@@ -1,3 +1,3 @@
 ## Supported clients
 
-To see the supported MySQL clients and examples about how to use them, take a look [here](https://github.com/src-d/go-mysql-server/blob/0093a7562ad1cf31f179396dfa5be32893059dbb/SUPPORTED_CLIENTS.md).
+To see the supported MySQL clients and examples about how to use them, take a look [here](https://github.com/src-d/go-mysql-server/blob/3dd441325d1731821eff0495fbf63747c258b8ff/SUPPORTED_CLIENTS.md).

--- a/docs/using-gitbase/supported-syntax.md
+++ b/docs/using-gitbase/supported-syntax.md
@@ -1,3 +1,3 @@
 ## Supported syntax
 
-To see the SQL subset currently supported take a look at [this list](https://github.com/src-d/go-mysql-server/blob/0093a7562ad1cf31f179396dfa5be32893059dbb/SUPPORTED.md) from [src-d/go-mysql-server](https://github.com/src-d/go-mysql-server).
+To see the SQL subset currently supported take a look at [this list](https://github.com/src-d/go-mysql-server/blob/3dd441325d1731821eff0495fbf63747c258b8ff/SUPPORTED.md) from [src-d/go-mysql-server](https://github.com/src-d/go-mysql-server).

--- a/integration_test.go
+++ b/integration_test.go
@@ -51,14 +51,14 @@ func TestIntegration(t *testing.T) {
 				ON c.blob_hash = b.blob_hash
 			GROUP BY c.commit_hash`,
 			[]sql.Row{
-				{int32(4), "1669dce138d9b841a518c64b10914d88f5e488ea"},
-				{int32(3), "35e85108805c84807bc66a02d91535e1e24b38b9"},
-				{int32(9), "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"},
-				{int32(8), "918c48b83bd081e863dbe1b80f8998f058cd8294"},
-				{int32(3), "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"},
-				{int32(6), "af2d6a6954d532f8ffb47615169c8fdf9d383a1a"},
-				{int32(2), "b029517f6300c2da0f4b651b8642506cd6aaf45d"},
-				{int32(3), "b8e471f58bcbca63b07bda20e428190409c2db47"},
+				{int64(4), "1669dce138d9b841a518c64b10914d88f5e488ea"},
+				{int64(3), "35e85108805c84807bc66a02d91535e1e24b38b9"},
+				{int64(9), "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"},
+				{int64(8), "918c48b83bd081e863dbe1b80f8998f058cd8294"},
+				{int64(3), "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"},
+				{int64(6), "af2d6a6954d532f8ffb47615169c8fdf9d383a1a"},
+				{int64(2), "b029517f6300c2da0f4b651b8642506cd6aaf45d"},
+				{int64(3), "b8e471f58bcbca63b07bda20e428190409c2db47"},
 			},
 		},
 		{
@@ -98,7 +98,7 @@ func TestIntegration(t *testing.T) {
 				LIMIT 1
 			) repo_years
 			GROUP BY first_commit_year`,
-			[]sql.Row{{int32(1), int32(2015)}},
+			[]sql.Row{{int64(1), int32(2015)}},
 		},
 		{
 			`SELECT COUNT(*) as num_commits, month, repo_id, committer_email
@@ -113,9 +113,9 @@ func TestIntegration(t *testing.T) {
 			) as t
 			GROUP BY committer_email, month, repo_id`,
 			[]sql.Row{
-				{int32(6), int32(3), "worktree", "mcuadros@gmail.com"},
-				{int32(1), int32(4), "worktree", "mcuadros@gmail.com"},
-				{int32(1), int32(3), "worktree", "daniel@lordran.local"},
+				{int64(6), int32(3), "worktree", "mcuadros@gmail.com"},
+				{int64(1), int32(4), "worktree", "mcuadros@gmail.com"},
+				{int64(1), int32(3), "worktree", "daniel@lordran.local"},
 			},
 		},
 		{
@@ -127,14 +127,14 @@ func TestIntegration(t *testing.T) {
 				GROUP BY c.commit_hash
 			) t WHERE num > 1`,
 			[]sql.Row{
-				{int32(3), "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"},
-				{int32(4), "918c48b83bd081e863dbe1b80f8998f058cd8294"},
-				{int32(4), "af2d6a6954d532f8ffb47615169c8fdf9d383a1a"},
-				{int32(4), "1669dce138d9b841a518c64b10914d88f5e488ea"},
-				{int32(4), "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"},
-				{int32(4), "b8e471f58bcbca63b07bda20e428190409c2db47"},
-				{int32(4), "35e85108805c84807bc66a02d91535e1e24b38b9"},
-				{int32(4), "b029517f6300c2da0f4b651b8642506cd6aaf45d"},
+				{int64(3), "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"},
+				{int64(4), "918c48b83bd081e863dbe1b80f8998f058cd8294"},
+				{int64(4), "af2d6a6954d532f8ffb47615169c8fdf9d383a1a"},
+				{int64(4), "1669dce138d9b841a518c64b10914d88f5e488ea"},
+				{int64(4), "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"},
+				{int64(4), "b8e471f58bcbca63b07bda20e428190409c2db47"},
+				{int64(4), "35e85108805c84807bc66a02d91535e1e24b38b9"},
+				{int64(4), "b029517f6300c2da0f4b651b8642506cd6aaf45d"},
 			},
 		},
 		{
@@ -145,7 +145,7 @@ func TestIntegration(t *testing.T) {
 				WHERE refs.ref_name = 'HEAD'
 				GROUP BY refs.repository_id`,
 			[]sql.Row{
-				{int32(9), "worktree"},
+				{int64(9), "worktree"},
 			},
 		},
 		{
@@ -154,15 +154,15 @@ func TestIntegration(t *testing.T) {
 			NATURAL JOIN files f
 			GROUP BY c.commit_hash`,
 			[]sql.Row{
-				{"b8e471f58bcbca63b07bda20e428190409c2db47", int32(3)},
-				{"b029517f6300c2da0f4b651b8642506cd6aaf45d", int32(2)},
-				{"af2d6a6954d532f8ffb47615169c8fdf9d383a1a", int32(6)},
-				{"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69", int32(3)},
-				{"918c48b83bd081e863dbe1b80f8998f058cd8294", int32(8)},
-				{"1669dce138d9b841a518c64b10914d88f5e488ea", int32(4)},
-				{"35e85108805c84807bc66a02d91535e1e24b38b9", int32(3)},
-				{"e8d3ffab552895c19b9fcf7aa264d277cde33881", int32(9)},
-				{"6ecf0ef2c2dffb796033e5a02219af86ec6584e5", int32(9)},
+				{"b8e471f58bcbca63b07bda20e428190409c2db47", int64(3)},
+				{"b029517f6300c2da0f4b651b8642506cd6aaf45d", int64(2)},
+				{"af2d6a6954d532f8ffb47615169c8fdf9d383a1a", int64(6)},
+				{"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69", int64(3)},
+				{"918c48b83bd081e863dbe1b80f8998f058cd8294", int64(8)},
+				{"1669dce138d9b841a518c64b10914d88f5e488ea", int64(4)},
+				{"35e85108805c84807bc66a02d91535e1e24b38b9", int64(3)},
+				{"e8d3ffab552895c19b9fcf7aa264d277cde33881", int64(9)},
+				{"6ecf0ef2c2dffb796033e5a02219af86ec6584e5", int64(9)},
 			},
 		},
 		{
@@ -325,26 +325,26 @@ func TestIntegration(t *testing.T) {
 			ORDER  BY repository_count DESC
 			`,
 			[]sql.Row{
-				{"Text", int32(1)},
-				{"Ignore List", int32(1)},
+				{"Text", int64(1)},
+				{"Ignore List", int64(1)},
 			},
 		},
 		{
 			`
-			SELECT 
+			SELECT
 				repository_id,
-				contributor_count 
+				contributor_count
 			FROM (
-				SELECT 
-					repository_id, 
-					COUNT(DISTINCT commit_author_email) AS contributor_count 
-				FROM commits 
+				SELECT
+					repository_id,
+					COUNT(DISTINCT commit_author_email) AS contributor_count
+				FROM commits
 				GROUP BY repository_id
-			) AS q 
-			ORDER BY contributor_count DESC 
+			) AS q
+			ORDER BY contributor_count DESC
 			LIMIT 10
 			`,
-			[]sql.Row{{"worktree", int32(9)}},
+			[]sql.Row{{"worktree", int64(9)}},
 		},
 	}
 

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/internal/regex/regex_go.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/internal/regex/regex_go.go
@@ -1,5 +1,3 @@
-// +build mysql_go_regex
-
 package regex
 
 import (

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/internal/regex/regex_oniguruma.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/internal/regex/regex_oniguruma.go
@@ -1,3 +1,5 @@
+// +build oniguruma
+
 package regex
 
 import (

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/analyzer/pushdown.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/analyzer/pushdown.go
@@ -329,7 +329,10 @@ func (i *releaseIter) Next() (sql.Row, error) {
 	return row, nil
 }
 
-func (i *releaseIter) Close() error {
+func (i *releaseIter) Close() (err error) {
 	i.once.Do(i.release)
-	return nil
+	if i.child != nil {
+		err = i.child.Close()
+	}
+	return err
 }

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/expression/function/aggregation/count.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/expression/function/aggregation/count.go
@@ -19,12 +19,12 @@ func NewCount(e sql.Expression) *Count {
 
 // NewBuffer creates a new buffer for the aggregation.
 func (c *Count) NewBuffer() sql.Row {
-	return sql.NewRow(int32(0))
+	return sql.NewRow(int64(0))
 }
 
 // Type returns the type of the result.
 func (c *Count) Type() sql.Type {
-	return sql.Int32
+	return sql.Int64
 }
 
 // IsNullable returns whether the return value can be null.
@@ -71,7 +71,7 @@ func (c *Count) Update(ctx *sql.Context, buffer, row sql.Row) error {
 	}
 
 	if inc {
-		buffer[0] = buffer[0].(int32) + int32(1)
+		buffer[0] = buffer[0].(int64) + int64(1)
 	}
 
 	return nil
@@ -79,7 +79,7 @@ func (c *Count) Update(ctx *sql.Context, buffer, row sql.Row) error {
 
 // Merge implements the Aggregation interface.
 func (c *Count) Merge(ctx *sql.Context, buffer, partial sql.Row) error {
-	buffer[0] = buffer[0].(int32) + partial[0].(int32)
+	buffer[0] = buffer[0].(int64) + partial[0].(int64)
 	return nil
 }
 

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/index/pilosa/driver.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/index/pilosa/driver.go
@@ -251,6 +251,7 @@ func (d *Driver) savePartition(
 		}
 
 		idx.mapping.close()
+		kviter.Close()
 	}()
 
 	for colID = offset; err == nil; colID++ {
@@ -344,6 +345,7 @@ func (d *Driver) Save(
 		return err
 	}
 
+	defer iter.Close()
 	pilosaIndex := idx.index
 	var rows uint64
 	for {

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/plan/cross_join.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/plan/cross_join.go
@@ -155,17 +155,18 @@ func (i *crossJoinIterator) Next() (sql.Row, error) {
 	}
 }
 
-func (i *crossJoinIterator) Close() error {
-	if err := i.l.Close(); err != nil {
-		if i.r != nil {
-			_ = i.r.Close()
-		}
-		return err
+func (i *crossJoinIterator) Close() (err error) {
+	if i.l != nil {
+		err = i.l.Close()
 	}
 
 	if i.r != nil {
-		return i.r.Close()
+		if err == nil {
+			err = i.r.Close()
+		} else {
+			i.r.Close()
+		}
 	}
 
-	return nil
+	return err
 }

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/plan/innerjoin.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/plan/innerjoin.go
@@ -355,19 +355,22 @@ func (i *innerJoinIter) Next() (sql.Row, error) {
 	}
 }
 
-func (i *innerJoinIter) Close() error {
-	if err := i.l.Close(); err != nil {
-		if i.r != nil {
-			_ = i.r.Close()
+func (i *innerJoinIter) Close() (err error) {
+	i.right = nil
+
+	if i.l != nil {
+		if err = i.l.Close(); err != nil {
+			if i.r != nil {
+				_ = i.r.Close()
+			}
+			return err
 		}
-		return err
+
 	}
 
 	if i.r != nil {
-		return i.r.Close()
+		err = i.r.Close()
 	}
 
-	i.right = nil
-
-	return nil
+	return err
 }

--- a/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/plan/process.go
+++ b/vendor/gopkg.in/src-d/go-mysql-server.v0/sql/plan/process.go
@@ -183,9 +183,12 @@ func (i *trackedIndexKeyValueIter) done() {
 	}
 }
 
-func (i *trackedIndexKeyValueIter) Close() error {
+func (i *trackedIndexKeyValueIter) Close() (err error) {
 	i.done()
-	return nil
+	if i.iter != nil {
+		err = i.iter.Close()
+	}
+	return err
 }
 
 func (i *trackedIndexKeyValueIter) Next() ([]interface{}, []byte, error) {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
This PR upgrades mysql dependency. New mysql-server contains the second part of closed iterators fix and makes go regex as a default engine.
At the same time (having go regex as a default) it closes https://github.com/src-d/gitbase/issues/778
