### PR TITLE
Add GO_BUILD_ARGS to static-build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ static-build: VERSION ?= $(shell git describe --exact-match --tags 2>/dev/null |
 static-build: LD_FLAGS += -linkmode external -extldflags '-static -lz' -s -w
 static-build: GO_BUILD_PATH ?= github.com/src-d/gitbase/...
 static-build:
-	go build -ldflags="$(LD_FLAGS)" -v  $(GO_BUILD_PATH)
+	go build $(GO_BUILD_ARGS) -ldflags="$(LD_FLAGS)" -v  $(GO_BUILD_PATH)
 
 ci-e2e: packages
 	go test ./e2e -gitbase-version="$(TRAVIS_TAG)" \


### PR DESCRIPTION
Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->