### PR TITLE
Set correct version on static-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ static-package:
 	docker rm gitbase-temp
 
 # target used in the Dockerfile to build the static binary
-static-build: VERSION ?= $(shell git describe --exact-match --tags 2>/dev/null || "dev-$(git rev-parse --short HEAD)$(test -n "`git status --porcelain`" && echo "-dirty" || true)")
+static-build: VERSION = $(shell git describe --exact-match --tags 2>/dev/null || "dev-$(git rev-parse --short HEAD)$(test -n "`git status --porcelain`" && echo "-dirty" || true)")
 static-build: LD_FLAGS += -linkmode external -extldflags '-static -lz' -s -w
 static-build: GO_BUILD_PATH ?= github.com/src-d/gitbase/...
 static-build:


### PR DESCRIPTION
Right now, we are compiling into a container. Doing this Makefile.main
is not getting correct VERSION env var because we don't have TRAVIS_TAG
in the container.

To avoid this problem, we are setting always our VERSION when `make
static-build` is called.

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->