### PR TITLE
Don't skip repos for remotes table with more than 1 URL

### DIFF
--- a/commits_test.go
+++ b/commits_test.go
@@ -304,3 +304,8 @@ func TestCommitsIndexIterClosed(t *testing.T) {
 func TestCommitsIterClosed(t *testing.T) {
 	testTableIterClosed(t, new(commitsTable))
 }
+
+func TestCommitsIterators(t *testing.T) {
+	// columns names just for debugging
+	testTableIterators(t, new(commitsTable), []string{"commit_hash", "commit_author_email"})
+}

--- a/references_test.go
+++ b/references_test.go
@@ -140,3 +140,8 @@ func TestReferencesIndexIterClosed(t *testing.T) {
 func TestReferencesIterClosed(t *testing.T) {
 	testTableIterClosed(t, new(referencesTable))
 }
+
+func TestReferencesIterators(t *testing.T) {
+	// columns names just for debugging
+	testTableIterators(t, new(referencesTable), []string{"ref_name", "commit_hash"})
+}

--- a/remotes.go
+++ b/remotes.go
@@ -174,12 +174,12 @@ func (i *remotesRowIter) Close() error {
 }
 
 func remoteToRow(repoID string, config *config.RemoteConfig, pos int) sql.Row {
-	url := ""
+	var url interface{}
 	if pos < len(config.URLs) {
 		url = config.URLs[pos]
 	}
 
-	fetch := ""
+	var fetch interface{}
 	if pos < len(config.Fetch) {
 		fetch = config.Fetch[pos].String()
 	}

--- a/remotes.go
+++ b/remotes.go
@@ -144,28 +144,25 @@ type remotesRowIter struct {
 }
 
 func (i *remotesRowIter) Next() (sql.Row, error) {
-	if i.remotePos >= len(i.remotes) {
-		return nil, io.EOF
-	}
-
-	remote := i.remotes[i.remotePos]
-	config := remote.Config()
-
-	if i.urlPos >= len(config.URLs) || i.urlPos >= len(config.Fetch) {
-		i.remotePos++
+	for {
 		if i.remotePos >= len(i.remotes) {
 			return nil, io.EOF
 		}
 
-		remote = i.remotes[i.remotePos]
-		config = remote.Config()
-		i.urlPos = 0
+		remote := i.remotes[i.remotePos]
+		config := remote.Config()
+
+		if i.urlPos >= len(config.URLs) && i.urlPos >= len(config.Fetch) {
+			i.remotePos++
+			i.urlPos = 0
+			continue
+		}
+
+		row := remoteToRow(i.repo.ID, config, i.urlPos)
+		i.urlPos++
+
+		return row, nil
 	}
-
-	row := remoteToRow(i.repo.ID, config, i.urlPos)
-	i.urlPos++
-
-	return row, nil
 }
 
 func (i *remotesRowIter) Close() error {
@@ -177,13 +174,23 @@ func (i *remotesRowIter) Close() error {
 }
 
 func remoteToRow(repoID string, config *config.RemoteConfig, pos int) sql.Row {
+	url := ""
+	if pos < len(config.URLs) {
+		url = config.URLs[pos]
+	}
+
+	fetch := ""
+	if pos < len(config.Fetch) {
+		fetch = config.Fetch[pos].String()
+	}
+
 	return sql.NewRow(
 		repoID,
 		config.Name,
-		config.URLs[pos],
-		config.URLs[pos],
-		config.Fetch[pos].String(),
-		config.Fetch[pos].String(),
+		url,
+		url,
+		fetch,
+		fetch,
 	)
 }
 
@@ -256,7 +263,8 @@ func (i *remotesKeyValueIter) Next() ([]interface{}, []byte, error) {
 		}
 
 		cfg := i.remotes[i.pos].Config()
-		if i.urlPos >= len(cfg.URLs) {
+		if i.urlPos >= len(cfg.URLs) && i.urlPos >= len(cfg.Fetch) {
+			i.urlPos = 0
 			i.pos++
 			continue
 		}

--- a/remotes_test.go
+++ b/remotes_test.go
@@ -150,6 +150,7 @@ func TestRemotesIndexIterClosed(t *testing.T) {
 	testTableIndexIterClosed(t, new(remotesTable))
 }
 
-func TestRemotesIterClosed(t *testing.T) {
-	testTableIterClosed(t, new(remotesTable))
+func TestRemotesIterators(t *testing.T) {
+	// columns names just for debugging
+	testTableIterators(t, new(remotesTable), []string{"remote_name", "remote_push_url"})
 }


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

Fixes https://github.com/src-d/gitbase/issues/788

For remotes with more than 1 URL, `remotesIndexKeyValueIter` skip repos.