### PR TITLE
cmd/server/commands: use relative path as id instead of last part

### DIFF
--- a/cmd/gitbase/command/server_test.go
+++ b/cmd/gitbase/command/server_test.go
@@ -1,7 +1,9 @@
 package command
 
 import (
+	"io"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/src-d/gitbase"
@@ -31,6 +33,33 @@ func TestAddMatch(t *testing.T) {
 	}
 	c := &Server{pool: gitbase.NewRepositoryPool(0)}
 	for _, e := range expected {
-		e.err(c.addMatch(e.path))
+		e.err(c.addMatch("../../../_testdata", e.path))
 	}
+}
+
+func TestAddDirectory(t *testing.T) {
+	require := require.New(t)
+	c := &Server{pool: gitbase.NewRepositoryPool(0), Depth: 5}
+	require.NoError(c.addDirectory("../../../_testdata/*"))
+	i, err := c.pool.RepoIter()
+	require.NoError(err)
+
+	var repositories []string
+	for {
+		r, err := i.Next()
+		if err == io.EOF {
+			require.NoError(i.Close())
+			break
+		}
+
+		repositories = append(repositories, r.ID)
+	}
+
+	sort.Strings(repositories)
+	expected := []string{
+		"05893125684f2d3943cd84a7ab2b75e53668fba1.siva",
+		"ff/fff840f8784ef162dc83a1465fc5763d890b68ba.siva",
+		"fff7062de8474d10a67d417ccea87ba6f58ca81d.siva",
+	}
+	require.Equal(expected, repositories)
 }

--- a/path_utils.go
+++ b/path_utils.go
@@ -12,6 +12,7 @@ import (
 var RegMatchChars = regexp.MustCompile(`(^|[^\\])([*[?])`)
 
 // StripPrefix removes the root path from the given path. Root may be a glob.
+// The returned string has all backslashes replaced with slashes.
 func StripPrefix(root, path string) (string, error) {
 	var err error
 	root, err = filepath.Abs(cleanGlob(root))
@@ -19,7 +20,7 @@ func StripPrefix(root, path string) (string, error) {
 		return "", err
 	}
 
-	if !strings.HasSuffix(root, string(filepath.Separator)) {
+	if !strings.HasSuffix(root, "/") {
 		root += string(filepath.Separator)
 	}
 
@@ -28,13 +29,15 @@ func StripPrefix(root, path string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimPrefix(path, root), nil
+	return strings.TrimPrefix(filepath.ToSlash(path), root), nil
 }
 
-// cleanGlob removes all the parts of a glob that are not fixed.
+// cleanGlob removes all the parts of a glob that are not fixed. It also
+// converts all slashes or backslashes to /.
 func cleanGlob(pattern string) string {
+	pattern = filepath.ToSlash(pattern)
 	var parts []string
-	for _, part := range strings.Split(pattern, string(filepath.Separator)) {
+	for _, part := range strings.Split(pattern, "/") {
 		if strings.ContainsAny(part, "*?[\\") {
 			break
 		}
@@ -42,7 +45,7 @@ func cleanGlob(pattern string) string {
 		parts = append(parts, part)
 	}
 
-	return strings.Join(parts, string(filepath.Separator))
+	return strings.Join(parts, "/")
 }
 
 // PatternMatches returns the paths matched and any error found.

--- a/path_utils.go
+++ b/path_utils.go
@@ -11,6 +11,40 @@ import (
 // RegMatchChars matches a string with a glob expression inside.
 var RegMatchChars = regexp.MustCompile(`(^|[^\\])([*[?])`)
 
+// StripPrefix removes the root path from the given path. Root may be a glob.
+func StripPrefix(root, path string) (string, error) {
+	var err error
+	root, err = filepath.Abs(cleanGlob(root))
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasSuffix(root, string(filepath.Separator)) {
+		root += string(filepath.Separator)
+	}
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimPrefix(path, root), nil
+}
+
+// cleanGlob removes all the parts of a glob that are not fixed.
+func cleanGlob(pattern string) string {
+	var parts []string
+	for _, part := range strings.Split(pattern, string(filepath.Separator)) {
+		if strings.ContainsAny(part, "*?[\\") {
+			break
+		}
+
+		parts = append(parts, part)
+	}
+
+	return strings.Join(parts, string(filepath.Separator))
+}
+
 // PatternMatches returns the paths matched and any error found.
 func PatternMatches(pattern string) ([]string, error) {
 	abs, err := filepath.Abs(pattern)

--- a/path_utils_test.go
+++ b/path_utils_test.go
@@ -61,3 +61,51 @@ func TestIsSivaFile(t *testing.T) {
 	require.True(IsSivaFile("is.siva"))
 	require.False(IsSivaFile("not-siva"))
 }
+
+func TestStripPrefix(t *testing.T) {
+	testCases := []struct {
+		root     string
+		path     string
+		expected string
+	}{
+		{
+			"_testdata/*",
+			"_testdata/05893125684f2d3943cd84a7ab2b75e53668fba1.siva",
+			"05893125684f2d3943cd84a7ab2b75e53668fba1.siva",
+		},
+		{
+			"_testdata/*",
+			"_testdata/foo/05893125684f2d3943cd84a7ab2b75e53668fba1.siva",
+			"foo/05893125684f2d3943cd84a7ab2b75e53668fba1.siva",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.path, func(t *testing.T) {
+			output, err := StripPrefix(tt.root, tt.path)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, output)
+		})
+	}
+}
+
+func TestCleanGlob(t *testing.T) {
+	testCases := []struct {
+		pattern  string
+		expected string
+	}{
+		{"../../../_testdata/?epositories", "../../../_testdata"},
+		{"../../../_testdata/**/repositories", "../../../_testdata"},
+		{"../../../_testdata/*/repositories", "../../../_testdata"},
+		{"../../../_testdata/*", "../../../_testdata"},
+		{"../../../_testdata/\\*/foo", "../../../_testdata"},
+		{"../../../_testdata/[a-z]/foo", "../../../_testdata"},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.pattern, func(t *testing.T) {
+			output := cleanGlob(tt.pattern)
+			require.Equal(t, tt.expected, output)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #681

Still can have collisions, but reduces the probability of having them.

Signed-off-by: Miguel Molina <miguel@erizocosmi.co>

<!--

All PRs must keep the documentation up to date. If this PR changes or adds some new behavior don't forget to check:

- Schema changes
- Syntax changes
- Add or update examples
- `go run ./tools/rev-upgrade/main.go -p "gopkg.in/src-d/go-mysql-server.v0" [-r "revision"]`

 -->