### PR TITLE
cli: log repositories found on startup

### DIFF
--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -290,7 +290,16 @@ func (c *Server) addDirectories() error {
 		}
 	}
 
-	return nil
+	repos, err := c.rootLibrary.Repositories(borges.ReadOnlyMode)
+	if err != nil {
+		return err
+	}
+
+	return repos.ForEach(func(r borges.Repository) error {
+		id := r.ID().String()
+		logrus.WithField("id", id).Debug("repository added")
+		return r.Close()
+	})
 }
 
 func (c *Server) addDirectory(d directory) error {

--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -294,6 +294,7 @@ func (c *Server) addDirectories() error {
 	if err != nil {
 		return err
 	}
+	defer repos.Close()
 
 	return repos.ForEach(func(r borges.Repository) error {
 		id := r.ID().String()


### PR DESCRIPTION
Uses the same log message as before except that instead of `path` it's `id`.
 
 - [x] I updated the documentation explaining the new behavior if any.
 - [x] I updated CHANGELOG.md file adding the new feature or bug fix.
 - [x] I updated go-mysql-server using `make upgrade` command if applicable.
 - [x] I added or updated examples if applicable.
 - [x] I checked that changes on schema are reflected into the documentation, if applicable.