### PR TITLE
gitbase: use only one cache for all repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - git libraries bare or non bare format is automatically detected ([#897](https://github.com/src-d/gitbase/pull/897))
+- Fix bug that created multiple object cache with incorrect size ([#898](https://github.com/src-d/gitbase/pull/898))
 
 ## [0.22.0-beta1] - 2019-06-20
 

--- a/cmd/gitbase/command/server.go
+++ b/cmd/gitbase/command/server.go
@@ -225,10 +225,10 @@ func (c *Server) buildDatabase() error {
 		)
 	}
 
-	c.rootLibrary = libraries.New(libraries.Options{})
-	c.pool = gitbase.NewRepositoryPool(c.CacheSize*cache.MiByte, c.rootLibrary)
+	c.sharedCache = cache.NewObjectLRU(c.CacheSize * cache.MiByte)
 
-	c.sharedCache = cache.NewObjectLRU(512 * cache.MiByte)
+	c.rootLibrary = libraries.New(libraries.Options{})
+	c.pool = gitbase.NewRepositoryPool(c.sharedCache, c.rootLibrary)
 
 	if err := c.addDirectories(); err != nil {
 		return err

--- a/common_test.go
+++ b/common_test.go
@@ -49,7 +49,7 @@ func buildSession(
 	lib, err := newMultiLibrary()
 	require.NoError(err)
 
-	pool := NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 	for _, fixture := range repos {
 		path := fixture.Worktree().Root()
 		ok, err := IsGitRepo(path)
@@ -173,7 +173,7 @@ func setupSivaCloseRepos(t *testing.T, dir string) (*sql.Context, *closedLibrary
 	require.NoError(err)
 
 	closedLib := &closedLibrary{multiLibrary: lib}
-	pool := NewRepositoryPool(cache.DefaultMaxSize, closedLib)
+	pool := NewRepositoryPool(cache.NewObjectLRUDefault(), closedLib)
 
 	cwd, err := os.Getwd()
 	require.NoError(err)
@@ -298,7 +298,7 @@ func newMultiPool() (*multiLibrary, *RepositoryPool, error) {
 		return nil, nil, err
 	}
 
-	pool := NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 
 	return lib, pool, err
 }

--- a/database_test.go
+++ b/database_test.go
@@ -15,7 +15,7 @@ func TestDatabase_Tables(t *testing.T) {
 	require := require.New(t)
 
 	lib := libraries.New(libraries.Options{})
-	db := getDB(t, testDBName, NewRepositoryPool(0, lib))
+	db := getDB(t, testDBName, NewRepositoryPool(nil, lib))
 
 	tables := db.Tables()
 	var tableNames []string
@@ -46,7 +46,7 @@ func TestDatabase_Name(t *testing.T) {
 	require := require.New(t)
 
 	lib := libraries.New(libraries.Options{})
-	db := getDB(t, testDBName, NewRepositoryPool(0, lib))
+	db := getDB(t, testDBName, NewRepositoryPool(nil, lib))
 	require.Equal(testDBName, db.Name())
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -51,7 +51,7 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 	lib.AddLocation(loc)
 
-	pool := gitbase.NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := gitbase.NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 	engine := newBaseEngine(pool)
 
 	testCases := []struct {
@@ -639,7 +639,7 @@ func TestMissingHeadRefs(t *testing.T) {
 	})
 	require.NoError(err)
 
-	pool := gitbase.NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := gitbase.NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 	engine := newBaseEngine(pool)
 
 	session := gitbase.NewSession(pool)
@@ -1013,7 +1013,7 @@ func setup(t testing.TB) (*sqle.Engine, *gitbase.RepositoryPool, func()) {
 	require.NoError(t, err)
 	lib.AddLocation(loc)
 
-	pool := gitbase.NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := gitbase.NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 
 	cleanup := func() {
 		require.NoError(t, fixtures.Clean())

--- a/internal/function/commit_stats_test.go
+++ b/internal/function/commit_stats_test.go
@@ -108,7 +108,7 @@ func setupPool(t *testing.T) (*gitbase.RepositoryPool, func()) {
 	require.NoError(t, err)
 	lib.AddLocation(loc)
 
-	pool := gitbase.NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := gitbase.NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 
 	return pool, cleanup
 }

--- a/internal/function/uast_test.go
+++ b/internal/function/uast_test.go
@@ -423,11 +423,6 @@ func bblfshFixtures(
 func setup(t *testing.T) (*sql.Context, func()) {
 	t.Helper()
 
-	// pool := gitbase.NewRepositoryPool(cache.DefaultMaxSize)
-	// for _, f := range fixtures.ByTag("worktree") {
-	// 	pool.AddGit(f.Worktree().Root())
-	// }
-
 	// create library directory and move repo inside
 
 	path := fixtures.ByTag("worktree").One().Worktree().Root()
@@ -445,7 +440,7 @@ func setup(t *testing.T) (*sql.Context, func()) {
 	require.NoError(t, err)
 	lib.AddLocation(loc)
 
-	pool := gitbase.NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := gitbase.NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 
 	session := gitbase.NewSession(pool)
 	ctx := sql.NewContext(context.TODO(), sql.WithSession(session))

--- a/internal/rule/squashjoins_test.go
+++ b/internal/rule/squashjoins_test.go
@@ -22,7 +22,7 @@ func TestAnalyzeSquashJoinsExchange(t *testing.T) {
 
 	catalog := sql.NewCatalog()
 	catalog.AddDatabase(
-		gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(0, lib)),
+		gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(nil, lib)),
 	)
 	a := analyzer.NewBuilder(catalog).
 		WithParallelism(2).
@@ -61,7 +61,7 @@ func TestAnalyzeSquashNaturalJoins(t *testing.T) {
 
 	catalog := sql.NewCatalog()
 	catalog.AddDatabase(
-		gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(0, lib)),
+		gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(nil, lib)),
 	)
 	a := analyzer.NewBuilder(catalog).
 		WithParallelism(2).
@@ -2289,7 +2289,7 @@ func TestIsJoinLeafSquashable(t *testing.T) {
 
 func TestOrderedTableNames(t *testing.T) {
 	lib := libraries.New(libraries.Options{})
-	tables := gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(0, lib)).Tables()
+	tables := gitbase.NewDatabase("foo", gitbase.NewRepositoryPool(nil, lib)).Tables()
 
 	input := []sql.Table{
 		tables[gitbase.BlobsTableName],
@@ -2831,5 +2831,5 @@ func (l dummyLookup) Indexes() []string {
 
 func gitbaseTables() map[string]sql.Table {
 	lib := libraries.New(libraries.Options{})
-	return gitbase.NewDatabase("", gitbase.NewRepositoryPool(0, lib)).Tables()
+	return gitbase.NewDatabase("", gitbase.NewRepositoryPool(nil, lib)).Tables()
 }

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -22,7 +22,7 @@ func TestRepositoriesTable(t *testing.T) {
 	lib, err := newMultiLibrary()
 	require.NoError(err)
 
-	pool := NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 	for _, id := range repoIDs {

--- a/repository_pool.go
+++ b/repository_pool.go
@@ -74,13 +74,13 @@ type RepositoryPool struct {
 	library borges.Library
 }
 
-// NewRepositoryPool initializes a new RepositoryPool with LRU cache.
+// NewRepositoryPool holds a repository library and a shared object cache.
 func NewRepositoryPool(
-	maxCacheSize cache.FileSize,
+	c cache.Object,
 	lib borges.Library,
 ) *RepositoryPool {
 	return &RepositoryPool{
-		cache:   cache.NewObjectLRU(maxCacheSize),
+		cache:   c,
 		library: lib,
 	}
 }

--- a/repository_pool_test.go
+++ b/repository_pool_test.go
@@ -20,7 +20,7 @@ func TestRepositoryPoolBasic(t *testing.T) {
 	lib, err := newMultiLibrary()
 	require.NoError(err)
 
-	pool := NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 
 	iter, err := pool.RepoIter()
 	require.NoError(err)
@@ -66,7 +66,7 @@ func TestRepositoryPoolGit(t *testing.T) {
 	lib, err := newMultiLibrary()
 	require.NoError(err)
 
-	pool := NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 
 	require.NoError(lib.AddPlain(path, path, nil))
 
@@ -107,7 +107,7 @@ func TestRepositoryPoolIterator(t *testing.T) {
 	lib, err := newMultiLibrary()
 	require.NoError(err)
 
-	pool := NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 	err = lib.AddPlain("0", path, nil)
 	require.NoError(err)
 	err = lib.AddPlain("1", path, nil)
@@ -145,7 +145,7 @@ func TestRepositoryPoolSiva(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(err)
 
-	pool := NewRepositoryPool(cache.DefaultMaxSize, lib)
+	pool := NewRepositoryPool(cache.NewObjectLRUDefault(), lib)
 	path := filepath.Join(cwd, "_testdata")
 
 	require.NoError(


### PR DESCRIPTION
Also fix a bug getting the cache size from cli.

Before integrating the use of `go-borges` repositories were managed by `RepositoryPool`. When it was created it initialized a git object cache that is used by all the repositories. This cache is also used when using indexes and reading directly from packfiles (cache is retrieved with `Repository.Cache()`, https://github.com/src-d/gitbase/blob/master/packfiles.go#L239).

Now `go-borges` takes care of repository libraries and retrieving go-git repositories from them. To make it work the same we initialize `go-borges` library with a cache generated in `gitbase` (`command.Server`) but I forgot that `RepositoryPool` was also generating a cache internally and returning it when calling `Repository.Cache()`. This means that there was two different objects caches, one for repositories opened without indexes and other for reading packfiles when the index was used. The problems are:

* It could theoretically use twice the amount of memory
* The objects in one of the cache won't be seen by the other so they will be read twice from disk

The change makes `RepositoryPool` get an initialized cache that will be used by all repos (both with and without index).

 - [x] I updated the documentation explaining the new behavior if any.
 - [x] I updated CHANGELOG.md file adding the new feature or bug fix.
 - [x] I updated go-mysql-server using `make upgrade` command if applicable.
 - [x] I added or updated examples if applicable.
 - [x] I checked that changes on schema are reflected into the documentation, if applicable.