### PR TITLE
Let the user define LOG_LEVEL=info using docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- When using `-v` verbose flag, will set `debug` as logging level, ignoring any other passed.
+
+### Fixed
+
+- If using docker image, and `info` logging level, it will be now used instead of `debug`.
+
+
 ## [0.24.0-beta1] - 2019-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- When using `-v` verbose flag, will set `debug` as logging level, ignoring any other passed.
+- When it's added the `-v` verbose flag, gitbase will use `debug` as logging level, ignoring any other passed ([#935](https://github.com/src-d/gitbase/pull/935))
 
 ### Fixed
 
-- If using docker image, and `info` logging level, it will be now used instead of `debug`.
+- If using docker image, and `info` logging level, it will be now used instead of `debug` ([#935](https://github.com/src-d/gitbase/pull/935))
 
 
 ## [0.24.0-beta1] - 2019-07-08

--- a/docs/using-gitbase/configuration.md
+++ b/docs/using-gitbase/configuration.md
@@ -117,6 +117,7 @@ Help Options:
       -r, --readonly                                   Only allow read queries. This disables creating and
                                                        deleting indexes as well. Cannot be used with
                                                        --user-file. [$GITBASE_READONLY]
-      -v                                               Activates the verbose mode
+      -v                                               Activates the verbose mode (equivalent to debug
+                                                       logging level), overwriting any passed logging level
           --log-level=[info|debug|warning|error|fatal] logging level (default: info) [$GITBASE_LOG_LEVEL]
 ```

--- a/init.sh
+++ b/init.sh
@@ -10,7 +10,9 @@ user=${GITBASE_USER}
 password=${GITBASE_PASSWORD}
 EOT
 
-/tini -s -- /bin/gitbase server -v \
+export GITBASE_LOG_LEVEL=${GITBASE_LOG_LEVEL:-debug}
+
+/tini -s -- /bin/gitbase server \
     --host=0.0.0.0 \
     --port=3306 \
     --user="$GITBASE_USER" \


### PR DESCRIPTION
fix #934

- docker entrypoint should not force the usage of 'verbose' mode
- docker entrypoint uses 'debug' log level as default if not defined (for backward compatibility)
- verbose flag will override any other passed log level, not only 'info'

 TODO;
 - [x] I updated the documentation explaining the new behavior if any.
 - [x] I updated CHANGELOG.md file adding the new feature or bug fix.
 
n/a
 - I added or updated examples if applicable.
 - I checked that changes on schema are reflected into the documentation, if applicable.
- I updated go-mysql-server using `make upgrade` command if applicable.