### PR TITLE
cleanup unused things from travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,10 @@ env:
 
 matrix:
   fast_finish: true
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-6
-    - g++-6
-    - libonig-dev
-
-
-before_install:
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90
 
 before_script:
   - docker run -d --name bblfshd --privileged -p 9432:9432 bblfsh/bblfshd:v2.14.0-drivers
   - docker exec -it bblfshd bblfshctl driver list
-  - go get -v github.com/go-sql-driver/mysql/...
 
 script:
   - make test-coverage codecov
@@ -62,8 +48,6 @@ jobs:
         - echo "skipping before_script for macOS"
 
       script:
-        - brew update
-        - brew install oniguruma
         - make packages || echo "" # will fail because of docker being missing
         - if [ ! -f "build/gitbase_darwin_amd64/gitbase" ]; then echo "gitbase binary not generated" && exit 1; fi
         - cd build


### PR DESCRIPTION
Removes all the installing we did for oniguruma that's now not required nor needed in the build.

 - [x] I updated the documentation explaining the new behavior if any.
 - [x] I updated CHANGELOG.md file adding the new feature or bug fix.
 - [x] I updated go-mysql-server using `make upgrade` command if applicable.
 - [x] I added or updated examples if applicable.
 - [x] I checked that changes on schema are reflected into the documentation, if applicable.