### PR TITLE
jenkinsfile -> change pipeline sequence

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,12 +29,6 @@ pipeline {
         sh '/bin/regression --complexity=2 --csv --prom local:HEAD'
       }
     }
-    stage('Run bblfsh mockup tests') {
-      when { branch 'master' }
-      steps {
-        sh '/bin/regression-bblfsh-mockups local:HEAD'
-      }
-    }
     stage('PR-run') {
       when { changeRequest target: 'master' }
       steps {
@@ -64,6 +58,12 @@ pipeline {
             )
           }
         }
+      }
+    }
+    stage('Run bblfsh mockup tests') {
+      when { branch 'master' }
+      steps {
+        sh '/bin/regression-bblfsh-mockups local:HEAD'
       }
     }
   }


### PR DESCRIPTION
currently issue https://github.com/src-d/gitbase/issues/955 forces pipeline to fail and jenkins plot is not built
this PR replaces stages so plot should be displayed before test has failed

also related to https://github.com/src-d/regression-gitbase/issues/25

Signed-off-by: lwsanty <lwsanty@gmail.com>
