### PR TITLE
function: use getLanguageCache helper in LOC function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only optimize sorted DISTINCT if the first column on the order by is on the distinct schema. ([#976](https://github.com/src-d/gitbase/issues/976))
 - Removed redundant commit information from BLAME results.
 - Don't abort, just warn, on git.Blame errors.
+- Avoid possible panics in LOC by using a safe cache accessor.
 
 ### Added
 

--- a/internal/function/loc.go
+++ b/internal/function/loc.go
@@ -75,7 +75,7 @@ func (f *LOC) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
-	lang, err := f.getLanguage(path, blob)
+	lang, err := getLanguage(ctx, path, blob)
 	if err != nil {
 		return nil, err
 	}
@@ -142,9 +142,10 @@ func (f *LOC) getInputValues(ctx *sql.Context, row sql.Row) (string, []byte, err
 	return path, blob, nil
 }
 
-func (f *LOC) getLanguage(path string, blob []byte) (string, error) {
+func getLanguage(ctx *sql.Context, path string, blob []byte) (string, error) {
 	hash := languageHash(path, blob)
 
+	languageCache := getLanguageCache(ctx)
 	value, err := languageCache.Get(hash)
 	if err == nil {
 		return value.(string), nil


### PR DESCRIPTION
Fixes #982

Language cache was migrated to the new cache API, but this part was
not, and when the cache has not been initialized yet it can lead to
a panic because it does not initialize the cache, only accesses it.

 - [x] I updated the documentation explaining the new behavior if any.
 - [x] I updated CHANGELOG.md file adding the new feature or bug fix.
 - [x] I updated go-mysql-server using `make upgrade` command if applicable.
 - [x] I added or updated examples if applicable.
 - [x] I checked that changes on schema are reflected into the documentation, if applicable.