### PR TITLE
chore: os.SEEK_CUR has been deprecated since Go 1.7

### DIFF
--- a/fs_error_test.go
+++ b/fs_error_test.go
@@ -3,6 +3,7 @@ package gitbase
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -225,7 +226,7 @@ type BrokenFile struct {
 }
 
 func (fs *BrokenFile) Read(p []byte) (int, error) {
-	_, err := fs.Seek(0, os.SEEK_CUR)
+	_, err := fs.Seek(0, io.SeekCurrent)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
 <!-- Add PR description here -->
 
 - [ ] I updated the documentation explaining the new behavior if any.
 - [ ] I updated CHANGELOG.md file adding the new feature or bug fix.
 - [ ] I updated go-mysql-server using `make upgrade` command if applicable.
 - [ ] I added or updated examples if applicable.
 - [ ] I checked that changes on schema are reflected into the documentation, if applicable.